### PR TITLE
feat: 新增 --file 文件上傳與 --model 模型切換功能

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,6 +19,7 @@ Unlike typical API clients, `ask` operates inside a real, headful Chrome browser
 - **🧠 Intelligent Tab Management**: Reuses existing ChatGPT tabs if open, focuses them, or opens new ones, avoiding tab clutter.
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask "summarize this"`).
 - **📎 Image & File Attachments**: Attach local images with `--image` or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; each flag can be specified multiple times.
+- **🔀 Model Switching**: Use `--model` to switch the ChatGPT model or thinking level (e.g. `GPT-5.4`, `o3`, `即時`) before the prompt is sent.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
 - **Version Info**: Use `-v` or `--version` to print the current version number.
 
@@ -181,7 +182,24 @@ You can attach images and documents at the same time:
 ask "Compare this design image against the spec document and list inconsistencies." --image design.png --file spec.docx
 ```
 
-### 9. Just Open ChatGPT
+### 9. Switch Model
+
+Use `--model` to automatically switch the ChatGPT model or thinking level before the prompt is sent. Matching is case- and punctuation-insensitive (`-`, `.`, spaces, etc. are ignored).
+
+```bash
+ask "Introduce Rust in a few sentences." --model GPT-5.4
+ask "Prove this math problem." --model o3
+ask "Quickly translate this." --model 即時
+```
+
+Available model names (depending on your account entitlements):
+
+- **Models**: `GPT-5.5`, `GPT-5.4`, `GPT-5.3`, `o3`
+- **Thinking levels**: `智慧`, `即時`, `中等`, `高`, `超高`, `專業`
+
+> If the requested name is not found in the menu, `ask` reports `Model switch failed: error: model not found in menu` and aborts without submitting the prompt.
+
+### 10. Just Open ChatGPT
 
 To quickly launch the browser and open ChatGPT without sending any query:
 

--- a/README.en.md
+++ b/README.en.md
@@ -18,6 +18,7 @@ Unlike typical API clients, `ask` operates inside a real, headful Chrome browser
 - **🌀 TUI Thinking Animation**: Displays a gorgeous, fluid rotating braille spinner (`⠋ 正在思考中 🧠...`) while waiting for ChatGPT to think and reply, which clears automatically the instant the streaming response starts.
 - **🧠 Intelligent Tab Management**: Reuses existing ChatGPT tabs if open, focuses them, or opens new ones, avoiding tab clutter.
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask "summarize this"`).
+- **📎 Image & File Attachments**: Attach local images with `--image` or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; each flag can be specified multiple times.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
 - **Version Info**: Use `-v` or `--version` to print the current version number.
 
@@ -149,7 +150,38 @@ Or read files:
 cat src/main.rs | ask "Are there any memory leaks in this Rust code?"
 ```
 
-### 8. Just Open ChatGPT
+### 8. Attaching Images or Files
+
+Instead of piping file contents into the prompt, you can upload local files as attachments directly to ChatGPT.
+
+#### Attach images
+
+Use `--image` (repeatable) to attach one or more local images:
+
+```bash
+ask "Describe this image." --image screenshot.png
+ask "Compare these two images." --image v1.png --image v2.png
+```
+
+Supported formats include PNG, JPEG, GIF, WebP, SVG, BMP, and more.
+
+#### Attach documents
+
+Use `--file` (repeatable) to attach documents such as PDF, Word, Excel, PowerPoint, plain text, Markdown, CSV, JSON, or source code:
+
+```bash
+ask "Summarize this PDF." --file report.pdf
+ask "How many rows are in this CSV?" --file data.csv
+ask "Check this code for issues." --file src/main.rs
+```
+
+You can attach images and documents at the same time:
+
+```bash
+ask "Compare this design image against the spec document and list inconsistencies." --image design.png --file spec.docx
+```
+
+### 9. Just Open ChatGPT
 
 To quickly launch the browser and open ChatGPT without sending any query:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **思考動畫**：等待 ChatGPT 回覆時，在終端機顯示旋轉 spinner，開始輸出內容後自動清除。
 - **智慧分頁管理**：可重用既有 ChatGPT 分頁、聚焦分頁，或開啟新分頁，避免分頁過度增加。
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask "summarize this"`。
+- **圖片與文件上傳**：可透過 `--image` 附上本機圖片，或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
 - **版本資訊**：使用 `-v` 或 `--version` 顯示目前版本號。
 
@@ -150,7 +151,42 @@ echo "用一句話解釋 quantum computing" | ask
 cat src/main.rs | ask "這段 Rust code 有記憶體洩漏風險嗎？"
 ```
 
-### 8. 只開啟 ChatGPT
+### 8. 附上圖片或文件
+
+除了把檔案內容透過 pipe 傳入 prompt，你也可以直接把本機檔案當作附件上傳給 ChatGPT。
+
+#### 附上圖片
+
+使用 `--image` 附上一或多張本機圖片（可重複指定）：
+
+```bash
+ask "請描述這張圖片的內容。" --image screenshot.png
+ask "比較這兩張圖的差異。" --image v1.png --image v2.png
+```
+
+支援的格式包含 PNG、JPEG、GIF、WebP、SVG、BMP 等。
+
+#### 附上文件
+
+使用 `--file` 附上一或多份本機文件（可重複指定），例如 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等：
+
+```bash
+ask "請摘要這份 PDF 的重點。" --file report.pdf
+ask "這份 CSV 總共有幾筆資料？" --file data.csv
+ask "幫我檢查這段程式碼有沒有問題。" --file src/main.rs
+```
+
+也可以同時附上圖片與文件：
+
+```bash
+ask "請對照這張設計圖與規格文件，指出不一致的地方。" --image design.png --file spec.docx
+```
+
+#### 顯示上傳結果
+
+ChatGPT 回覆後，可使用 `-i` / `--image-output` 指定 ChatGPT 生成圖片的下載路徑（資料夾或檔案路徑）。
+
+### 9. 只開啟 ChatGPT
 
 若只想快速開啟瀏覽器並進入 ChatGPT：
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **智慧分頁管理**：可重用既有 ChatGPT 分頁、聚焦分頁，或開啟新分頁，避免分頁過度增加。
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask "summarize this"`。
 - **圖片與文件上傳**：可透過 `--image` 附上本機圖片，或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案。
+- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 ChatGPT 模型或思考強度（如 `GPT-5.4`、`o3`、`即時`）。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
 - **版本資訊**：使用 `-v` 或 `--version` 顯示目前版本號。
 
@@ -186,7 +187,24 @@ ask "請對照這張設計圖與規格文件，指出不一致的地方。" --im
 
 ChatGPT 回覆後，可使用 `-i` / `--image-output` 指定 ChatGPT 生成圖片的下載路徑（資料夾或檔案路徑）。
 
-### 9. 只開啟 ChatGPT
+### 9. 切換模型
+
+使用 `--model` 在送出 prompt 前自動切換 ChatGPT 的模型或思考強度。比對時不分大小寫與標點符號（`-`、`.`、空格 等）。
+
+```bash
+ask "用幾句話介紹 Rust。" --model GPT-5.4
+ask "證明這個數學問題。" --model o3
+ask "快速翻譯這段話。" --model 即時
+```
+
+可用的模型名稱（視帳號權限而定）：
+
+- **模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
+- **思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
+
+> 若指定的名稱在選單中找不到，`ask` 會回報 `Model switch failed: error: model not found in menu` 並中止，不會送出 prompt。
+
+### 10. 只開啟 ChatGPT
 
 若只想快速開啟瀏覽器並進入 ChatGPT：
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,6 +82,35 @@ cat README.md | ask "摘要這份文件。"
 
 若未提供 prompt argument，`ask` 會從 standard input 讀取內容。
 
+## 附上圖片或文件
+
+`ask` 支援把本機檔案當作附件直接上傳給 ChatGPT，不必透過 pipe 把內容塞進 prompt。
+
+### 附上圖片
+
+使用 `--image`（可重複指定）：
+
+```sh
+ask "請描述這張圖片。" --image screenshot.png
+ask "比較這兩張圖。" --image v1.png --image v2.png
+```
+
+### 附上文件
+
+使用 `--file`（可重複指定）附上 PDF、Word、Excel、純文字、Markdown、CSV、JSON、程式碼等文件：
+
+```sh
+ask "請摘要這份 PDF。" --file report.pdf
+ask "這份 CSV 有幾筆資料？" --file data.csv
+ask "幫我檢查這段程式碼。" --file src/main.rs
+```
+
+也可以同時附上圖片與文件：
+
+```sh
+ask "對照這張設計圖與規格文件，指出不一致處。" --image design.png --file spec.docx
+```
+
 ## MCP 行為
 
 啟動時，`ask` 會把 MCP 設定寫入：

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -111,6 +111,21 @@ ask "幫我檢查這段程式碼。" --file src/main.rs
 ask "對照這張設計圖與規格文件，指出不一致處。" --image design.png --file spec.docx
 ```
 
+## 切換模型
+
+使用 `--model` 在送出 prompt 前自動切換 ChatGPT 模型或思考強度（不分大小寫與標點）：
+
+```sh
+ask "用幾句話介紹 Rust。" --model GPT-5.4
+ask "證明這個數學問題。" --model o3
+ask "快速翻譯這段話。" --model 即時
+```
+
+可用名稱（視帳號權限）：
+
+- **模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
+- **思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
+
 ## MCP 行為
 
 啟動時，`ask` 會把 MCP 設定寫入：

--- a/src/main.rs
+++ b/src/main.rs
@@ -1171,8 +1171,9 @@ fn display_image_in_terminal(image_path: &str) {
 }
 
 /// Map a file extension to a MIME type. Covers common image and document formats.
+/// `ext` is expected to already be lowercased by the caller.
 fn mime_type_for_extension(ext: &str) -> &'static str {
-    match ext.to_lowercase().as_str() {
+    match ext {
         // Images
         "png" => "image/png",
         "jpg" | "jpeg" => "image/jpeg",
@@ -1325,9 +1326,20 @@ fn upload_attachments_to_chatgpt(
         + "            }\n"
         + "            el.focus();\n"
         + "            const fileInputs = Array.from(document.querySelectorAll('input[type=\"file\"]'));\n"
-        + "            // Prefer a file input whose accept attribute allows arbitrary files/documents;\n"
-        + "            // fall back to the first available file input.\n"
-        + "            const fileInput = fileInputs.find(i => !i.accept || /\\*|\\/|pdf|document|word|excel|powerpoint|octet/i.test(i.accept)) || fileInputs[0];\n"
+        + "            // Pick the file input whose `accept` attribute covers every attached file.\n"
+        + "            // An input accepts a file when accept is empty, contains `*/*` or a matching\n"
+        + "            // wildcard (e.g. `image/*`), or lists the file's exact MIME type.\n"
+        + "            const accepts = (input, file) => {\n"
+        + "                const acc = (input.getAttribute('accept') || '').trim();\n"
+        + "                if (!acc) return true;\n"
+        + "                const parts = acc.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);\n"
+        + "                const mime = (file.type || '').toLowerCase();\n"
+        + "                const top = mime.split('/')[0];\n"
+        + "                return parts.some(p => p === '*/*' || p === mime || (p.endsWith('/*') && top && p === top + '/*'));\n"
+        + "            };\n"
+        + "            const fileInput = fileInputs.find(i => fileObjects.every(f => accepts(i, f)))\n"
+        + "                || fileInputs.find(i => !i.getAttribute('accept'))\n"
+        + "                || fileInputs[0];\n"
         + "            if (fileInput) {\n"
         + "                const dt = new DataTransfer();\n"
         + "                for (const f of fileObjects) dt.items.add(f);\n"
@@ -1362,7 +1374,7 @@ fn upload_attachments_to_chatgpt(
 
     let start_parsed = parse_script_result(&start_res)?;
     if !start_parsed.as_bool().unwrap_or(false) {
-        return Err("Failed to initiate image upload script".to_string());
+        return Err("Failed to initiate attachment upload script".to_string());
     }
 
     // Poll for completion. Allow up to ~60s for large document uploads.
@@ -1385,14 +1397,14 @@ fn upload_attachments_to_chatgpt(
     }
 
     if status.starts_with("error:") {
-        return Err(format!("Image upload failed: {}", status));
+        return Err(format!("Attachment upload failed: {}", status));
     }
     if status == "pending" {
-        return Err("Timed out waiting for images to upload".to_string());
+        return Err("Timed out waiting for attachments to upload".to_string());
     }
 
     if verbose {
-        println!("Images attached successfully ({})", status);
+        println!("Attachments attached successfully ({})", status);
     }
 
     // Give the UI a moment to render the attachments before typing the prompt
@@ -1435,7 +1447,12 @@ fn switch_model(config_path: &str, model: &str, verbose: bool) -> Result<(), Str
         + "            await sleep(400);\n"
         + "        };\n"
         + "        await closeMenus();\n"
-        + "        const pill = document.querySelector('button.__composer-pill');\n"
+        + "        let pill = null;\n"
+        + "        for (let i = 0; i < 20; i++) {\n"
+        + "            pill = document.querySelector('button.__composer-pill');\n"
+        + "            if (pill) break;\n"
+        + "            await sleep(250);\n"
+        + "        }\n"
         + "        if (!pill) { window.__switch_model_status = 'error: composer pill not found'; return; }\n"
         + "        pill.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));\n"
         + "        pill.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));\n"
@@ -2183,7 +2200,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut wait_cycles = 0;
     let mut status = String::from("pending");
-    while status == "pending" && wait_cycles < 50 {
+    // JS retry loop waits up to 15s for the send button to activate; poll at least that long
+    // (plus margin) so we don't time out before the page-side retry completes.
+    while status == "pending" && wait_cycles < 180 {
         thread::sleep(Duration::from_millis(100));
         let check_res = call_mcp_tool(
             &config_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
         short_alias = 'V',
         action = ArgAction::Version
     )]
-    _version: bool,
+    _version: (),
 
     /// Print verbose debugging status messages.
     #[arg(long, default_value_t = false)]
@@ -50,6 +50,11 @@ struct Cli {
     /// Attach one or more local image files to the prompt (can be specified multiple times).
     #[arg(long = "image", value_name = "IMAGE_FILE", num_args = 1)]
     images: Vec<String>,
+
+    /// Attach one or more local document files (PDF, Word, Excel, text, etc.) to the prompt
+    /// (can be specified multiple times).
+    #[arg(long = "file", value_name = "FILE", num_args = 1)]
+    files: Vec<String>,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -586,7 +591,11 @@ fn wait_for_page_load(config_path: &str, verbose: bool) -> Result<(), String> {
             }),
         );
 
-        if ready_res.and_then(|res| parse_script_result(&res)).map(|parsed| parsed.as_bool().unwrap_or(false)).unwrap_or(false) {
+        if ready_res
+            .and_then(|res| parse_script_result(&res))
+            .map(|parsed| parsed.as_bool().unwrap_or(false))
+            .unwrap_or(false)
+        {
             ready = true;
             break;
         }
@@ -619,7 +628,11 @@ fn wait_for_page_load(config_path: &str, verbose: bool) -> Result<(), String> {
             }),
         );
 
-        if element_res.and_then(|res| parse_script_result(&res)).map(|parsed| parsed.as_bool().unwrap_or(false)).unwrap_or(false) {
+        if element_res
+            .and_then(|res| parse_script_result(&res))
+            .map(|parsed| parsed.as_bool().unwrap_or(false))
+            .unwrap_or(false)
+        {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(250));
@@ -1017,7 +1030,10 @@ fn download_images_from_latest_message(
                 "function": "() => window.__downloaded_images_status || 'pending'"
             }),
         )?;
-        if let Some(s) = parse_script_result(&check_res).ok().and_then(|p| p.as_str().map(|str_ref| str_ref.to_string())) {
+        if let Some(s) = parse_script_result(&check_res)
+            .ok()
+            .and_then(|p| p.as_str().map(|str_ref| str_ref.to_string()))
+        {
             status = s;
         }
         wait_cycles += 1;
@@ -1106,16 +1122,16 @@ fn download_images_from_latest_message(
                 } else {
                     let parent = path.parent().unwrap_or_else(|| std::path::Path::new(""));
                     if !parent.as_os_str().is_empty() {
-                        std::fs::create_dir_all(parent)
-                            .map_err(|e| format!("Failed to create parent directory {:?}: {}", parent, e))?;
+                        std::fs::create_dir_all(parent).map_err(|e| {
+                            format!("Failed to create parent directory {:?}: {}", parent, e)
+                        })?;
                     }
-                    let file_stem = path.file_stem()
+                    let file_stem = path
+                        .file_stem()
                         .and_then(|s| s.to_str())
                         .ok_or_else(|| "Invalid file name".to_string())?;
-                    let file_ext = path.extension()
-                        .and_then(|e| e.to_str())
-                        .unwrap_or(ext);
-                    
+                    let file_ext = path.extension().and_then(|e| e.to_str()).unwrap_or(ext);
+
                     if total <= 1 {
                         parent.join(format!("{}.{}", file_stem, file_ext))
                     } else {
@@ -1133,7 +1149,10 @@ fn download_images_from_latest_message(
         std::fs::write(&file_path, decoded)
             .map_err(|e| format!("Failed to write image file {:?}: {}", file_path, e))?;
 
-        println!("📥 Downloaded and saved generated image to: {}", file_path.to_string_lossy());
+        println!(
+            "📥 Downloaded and saved generated image to: {}",
+            file_path.to_string_lossy()
+        );
     }
 
     Ok(())
@@ -1142,81 +1161,167 @@ fn download_images_from_latest_message(
 /// Display an image in the terminal using kitty's icat protocol.
 /// Silently skips if kitty icat is not available.
 fn display_image_in_terminal(image_path: &str) {
-    let _ = Command::new("kitty")
-        .args(["icat", image_path])
-        .status();
+    let _ = Command::new("kitty").args(["icat", image_path]).status();
 }
 
-/// Encode a local image file as a base64 data URL.
-fn image_to_data_url(path: &str) -> Result<String, String> {
-    let bytes = std::fs::read(path)
-        .map_err(|e| format!("Failed to read image file '{}': {}", path, e))?;
-    let ext = Path::new(path)
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("png")
-        .to_lowercase();
-    let mime = match ext.as_str() {
+/// Map a file extension to a MIME type. Covers common image and document formats.
+fn mime_type_for_extension(ext: &str) -> &'static str {
+    match ext.to_lowercase().as_str() {
+        // Images
+        "png" => "image/png",
         "jpg" | "jpeg" => "image/jpeg",
         "gif" => "image/gif",
         "webp" => "image/webp",
         "svg" => "image/svg+xml",
-        _ => "image/png",
-    };
-    let b64 = general_purpose::STANDARD.encode(&bytes);
-    Ok(format!("data:{};base64,{}", mime, b64))
+        "bmp" => "image/bmp",
+        "avif" => "image/avif",
+        "ico" => "image/x-icon",
+        // Documents
+        "pdf" => "application/pdf",
+        "doc" => "application/msword",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xls" => "application/vnd.ms-excel",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ppt" => "application/vnd.ms-powerpoint",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "odt" => "application/vnd.oasis.opendocument.text",
+        "ods" => "application/vnd.oasis.opendocument.spreadsheet",
+        "odp" => "application/vnd.oasis.opendocument.presentation",
+        "rtf" => "application/rtf",
+        "csv" => "text/csv",
+        "tsv" => "text/tab-separated-values",
+        "txt" => "text/plain",
+        "md" => "text/markdown",
+        "html" | "htm" => "text/html",
+        "xml" => "application/xml",
+        "json" => "application/json",
+        "yaml" | "yml" => "text/yaml",
+        "ts" => "text/typescript",
+        "tsx" => "text/typescript",
+        "js" | "mjs" | "cjs" => "text/javascript",
+        "jsx" => "text/javascript",
+        "css" => "text/css",
+        "py" => "text/x-python",
+        "rb" => "text/x-ruby",
+        "go" => "text/x-go",
+        "rs" => "text/x-rust",
+        "java" => "text/x-java",
+        "kt" => "text/x-kotlin",
+        "c" => "text/x-c",
+        "h" => "text/x-c",
+        "cpp" | "cc" | "cxx" => "text/x-c++",
+        "hpp" => "text/x-c++",
+        "cs" => "text/x-csharp",
+        "swift" => "text/x-swift",
+        "php" => "text/x-php",
+        "sh" => "application/x-sh",
+        "bash" => "application/x-sh",
+        "zsh" => "application/x-sh",
+        "sql" => "application/sql",
+        "toml" => "application/toml",
+        "ini" => "text/plain",
+        "log" => "text/plain",
+        // Archives
+        "zip" => "application/zip",
+        "gz" | "gzip" => "application/gzip",
+        "tar" => "application/x-tar",
+        "bz2" => "application/x-bzip2",
+        "7z" => "application/x-7z-compressed",
+        // Audio
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "m4a" => "audio/mp4",
+        "flac" => "audio/flac",
+        "ogg" => "audio/ogg",
+        // Video
+        "mp4" => "video/mp4",
+        "mov" => "video/quicktime",
+        "avi" => "video/x-msvideo",
+        "mkv" => "video/x-matroska",
+        "webm" => "video/webm",
+        _ => "application/octet-stream",
+    }
 }
 
-/// Upload local image files to the ChatGPT prompt textarea using the DataTransfer API.
-/// Returns an error string if any image fails to upload.
-fn upload_images_to_chatgpt(
+/// Upload local image and/or document files to the ChatGPT prompt composer using the
+/// DataTransfer API against the page's file input element.
+/// Returns an error string if any attachment fails to upload.
+fn upload_attachments_to_chatgpt(
     config_path: &str,
     image_paths: &[String],
+    file_paths: &[String],
     verbose: bool,
 ) -> Result<(), String> {
-    if image_paths.is_empty() {
+    let total = image_paths.len() + file_paths.len();
+    if total == 0 {
         return Ok(());
     }
 
     if verbose {
-        println!("Attaching {} image(s) to the prompt...", image_paths.len());
+        println!(
+            "Attaching {} attachment(s) ({} image(s), {} file(s)) to the prompt...",
+            total,
+            image_paths.len(),
+            file_paths.len()
+        );
     }
 
-    // Build a JSON array of { name, dataUrl } objects
+    // Build a JSON array of { name, mime, base64 } objects. Images first, then other files.
+    // We pass raw base64 + mime and decode in JS to avoid `fetch(data:...)` which ChatGPT's
+    // Content-Security-Policy blocks (results in "Failed to fetch").
     let mut files_json = Vec::new();
-    for path in image_paths {
-        let data_url = image_to_data_url(path)?;
+    for path in image_paths.iter().chain(file_paths.iter()) {
+        let bytes =
+            std::fs::read(path).map_err(|e| format!("Failed to read file '{}': {}", path, e))?;
+        let ext = Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let mime = mime_type_for_extension(&ext);
+        let b64 = general_purpose::STANDARD.encode(&bytes);
         let file_name = Path::new(path)
             .file_name()
             .and_then(|n| n.to_str())
-            .unwrap_or("image.png")
+            .unwrap_or("attachment")
             .to_string();
         files_json.push(serde_json::json!({
             "name": file_name,
-            "dataUrl": data_url
+            "mime": mime,
+            "base64": b64
         }));
     }
 
     let files_json_str = serde_json::to_string(&files_json)
-        .map_err(|e| format!("Failed to serialize image data: {}", e))?;
+        .map_err(|e| format!("Failed to serialize attachment data: {}", e))?;
     // Build JS without raw strings to avoid r#"..."# termination conflicts
     let js = "() => {\n".to_string()
         + "    window.__upload_images_status = 'pending';\n"
         + "    (async () => {\n"
         + "        try {\n"
         + &format!("            const filesData = {};\n", files_json_str)
-        + "            const fileObjects = await Promise.all(filesData.map(async (f) => {\n"
-        + "                const res = await fetch(f.dataUrl);\n"
-        + "                const blob = await res.blob();\n"
+        + "            const decodeB64 = (b64) => {\n"
+        + "                const bin = atob(b64);\n"
+        + "                const len = bin.length;\n"
+        + "                const bytes = new Uint8Array(len);\n"
+        + "                for (let i = 0; i < len; i++) bytes[i] = bin.charCodeAt(i);\n"
+        + "                return bytes;\n"
+        + "            };\n"
+        + "            const fileObjects = filesData.map((f) => {\n"
+        + "                const bytes = decodeB64(f.base64);\n"
+        + "                const blob = new Blob([bytes], { type: f.mime || 'application/octet-stream' });\n"
         + "                return new File([blob], f.name, { type: blob.type });\n"
-        + "            }));\n"
+        + "            });\n"
         + "            const el = document.getElementById('prompt-textarea');\n"
         + "            if (!el) {\n"
         + "                window.__upload_images_status = 'error: textarea not found';\n"
         + "                return;\n"
         + "            }\n"
         + "            el.focus();\n"
-        + "            const fileInput = document.querySelector('input[type=\"file\"]');\n"
+        + "            const fileInputs = Array.from(document.querySelectorAll('input[type=\"file\"]'));\n"
+        + "            // Prefer a file input whose accept attribute allows arbitrary files/documents;\n"
+        + "            // fall back to the first available file input.\n"
+        + "            const fileInput = fileInputs.find(i => !i.accept || /\\*|\\/|pdf|document|word|excel|powerpoint|octet/i.test(i.accept)) || fileInputs[0];\n"
         + "            if (fileInput) {\n"
         + "                const dt = new DataTransfer();\n"
         + "                for (const f of fileObjects) dt.items.add(f);\n"
@@ -1254,10 +1359,10 @@ fn upload_images_to_chatgpt(
         return Err("Failed to initiate image upload script".to_string());
     }
 
-    // Poll for completion
+    // Poll for completion. Allow up to ~60s for large document uploads.
     let mut wait_cycles = 0;
     let mut status = String::from("pending");
-    while status == "pending" && wait_cycles < 150 {
+    while status == "pending" && wait_cycles < 300 {
         thread::sleep(Duration::from_millis(200));
         let check_res = call_mcp_tool(
             config_path,
@@ -1448,8 +1553,19 @@ fn ensure_chatgpt_tab(
         if attempt > 0 && attempt % 10 == 0 {
             let page_opt = call_mcp_tool(config_path, "list_pages", serde_json::json!({}))
                 .ok()
-                .and_then(|res| res.get("content").and_then(|c| c.as_array()).and_then(|arr| arr.first()).and_then(|obj| obj.get("text")).and_then(|t| t.as_str()).map(|t| t.to_string()))
-                .and_then(|text| parse_pages(&text).into_iter().find(|p| p.url.contains("chatgpt.com")));
+                .and_then(|res| {
+                    res.get("content")
+                        .and_then(|c| c.as_array())
+                        .and_then(|arr| arr.first())
+                        .and_then(|obj| obj.get("text"))
+                        .and_then(|t| t.as_str())
+                        .map(|t| t.to_string())
+                })
+                .and_then(|text| {
+                    parse_pages(&text)
+                        .into_iter()
+                        .find(|p| p.url.contains("chatgpt.com"))
+                });
             if let Some(page) = page_opt {
                 let _ = call_mcp_tool(
                     config_path,
@@ -1564,9 +1680,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 eprintln!("Error rendering Markdown: {}", e);
                                 std::process::exit(1);
                             }
-                            if let Err(e) =
-                                download_images_from_latest_message(&config_path, cli.image_output.as_deref(), cli.verbose)
-                            {
+                            if let Err(e) = download_images_from_latest_message(
+                                &config_path,
+                                cli.image_output.as_deref(),
+                                cli.verbose,
+                            ) {
                                 eprintln!("Error downloading images: {}", e);
                             }
                         }
@@ -1613,9 +1731,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             eprintln!("Error rendering Markdown: {}", e);
                             std::process::exit(1);
                         }
-                        if let Err(e) =
-                            download_images_from_latest_message(&config_path, cli.image_output.as_deref(), cli.verbose)
-                        {
+                        if let Err(e) = download_images_from_latest_message(
+                            &config_path,
+                            cli.image_output.as_deref(),
+                            cli.verbose,
+                        ) {
                             eprintln!("Error downloading images: {}", e);
                         }
                     }
@@ -1690,7 +1810,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut saved = false;
                 if let Some(arr) = res.get("content").and_then(|c| c.as_array()) {
                     for item in arr {
-                        if let Some(data) = item.get("type")
+                        if let Some(data) = item
+                            .get("type")
                             .filter(|t| t.as_str() == Some("image"))
                             .and_then(|_| item.get("data"))
                             .and_then(|d| d.as_str())
@@ -1772,10 +1893,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => {}
     }
 
-    // Upload any attached images before counting messages (so the UI is ready)
-    if !cli.images.is_empty() {
-        if let Err(e) = upload_images_to_chatgpt(&config_path, &cli.images, cli.verbose) {
-            eprintln!("Error attaching images: {}", e);
+    // Upload any attached images/files before counting messages (so the UI is ready)
+    if !cli.images.is_empty() || !cli.files.is_empty() {
+        if let Err(e) =
+            upload_attachments_to_chatgpt(&config_path, &cli.images, &cli.files, cli.verbose)
+        {
+            eprintln!("Error attaching images/files: {}", e);
             std::process::exit(1);
         }
     }
@@ -1885,8 +2008,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         window.__submit_status = 'success:' + JSON.stringify(result);
                         return;
                     }}
-                    
-                    for (let i = 0; i < 30; i++) {{
+
+                    for (let i = 0; i < 150; i++) {{
                         await new Promise(r => setTimeout(r, 100));
                         result = findAndClickSendButton();
                         if (result) {{
@@ -1929,7 +2052,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "function": "() => window.__submit_status || 'pending'"
             }),
         )?;
-        if let Some(s) = parse_script_result(&check_res).ok().and_then(|p| p.as_str().map(|str_ref| str_ref.to_string())) {
+        if let Some(s) = parse_script_result(&check_res)
+            .ok()
+            .and_then(|p| p.as_str().map(|str_ref| str_ref.to_string()))
+        {
             status = s;
         }
         wait_cycles += 1;
@@ -2058,7 +2184,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if finished {
-        let _ = download_images_from_latest_message(&config_path, cli.image_output.as_deref(), cli.verbose).map_err(|e| {
+        let _ = download_images_from_latest_message(
+            &config_path,
+            cli.image_output.as_deref(),
+            cli.verbose,
+        )
+        .map_err(|e| {
             eprintln!("Error downloading images: {}", e);
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,12 @@ struct Cli {
     #[arg(long = "file", value_name = "FILE", num_args = 1)]
     files: Vec<String>,
 
+    /// Switch the ChatGPT model (or thinking level) before sending the prompt.
+    /// Examples: "GPT-5.5", "GPT-5.4", "GPT-5.3", "o3", or thinking levels such as
+    /// "即時", "中等", "高", "超高", "專業", "智慧". Matching is case- and punctuation-insensitive.
+    #[arg(long = "model", value_name = "MODEL")]
+    model: Option<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -1395,6 +1401,132 @@ fn upload_attachments_to_chatgpt(
     Ok(())
 }
 
+/// Switch the ChatGPT composer to the specified model or thinking level by driving
+/// the composer's pill menu (a Radix UI menu). The page must already be loaded and
+/// logged in. `model` is matched case- and punctuation-insensitively against the
+/// visible menu item labels (e.g. "GPT-5.4", "o3", "即時", "超高").
+fn switch_model(config_path: &str, model: &str, verbose: bool) -> Result<(), String> {
+    if model.trim().is_empty() {
+        return Err("Empty model name".to_string());
+    }
+    let target_json = serde_json::to_string(model.trim())
+        .map_err(|e| format!("Failed to serialize model name: {}", e))?;
+
+    if verbose {
+        println!("Switching ChatGPT model to '{}'...", model.trim());
+    }
+
+    // The script sets `window.__switch_model_status` and resolves asynchronously.
+    // It opens the composer pill menu, walks visible leaves and submenu triggers,
+    // clicking the first leaf whose normalized label equals the normalized target.
+    // Radix re-renders menus on each open/close, so submenu triggers are tracked by
+    // a stable key (normalized text + aria-label) rather than DOM identity.
+    let js = "() => {\n".to_string()
+        + "    window.__switch_model_status = 'pending';\n"
+        + "    (async () => {\n"
+        + "    try {\n"
+        + "        const sleep = (ms) => new Promise((r) => setTimeout(r, ms));\n"
+        + "        const norm = (s) => (s || '').toLowerCase().replace(/[\\s.\\-_]/g, '');\n"
+        + &format!("        const target = norm({});\n", target_json)
+        + "        if (!target) { window.__switch_model_status = 'error: empty target'; return; }\n"
+        + "        const visited = new Set();\n"
+        + "        const closeMenus = async () => {\n"
+        + "            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));\n"
+        + "            await sleep(400);\n"
+        + "        };\n"
+        + "        await closeMenus();\n"
+        + "        const pill = document.querySelector('button.__composer-pill');\n"
+        + "        if (!pill) { window.__switch_model_status = 'error: composer pill not found'; return; }\n"
+        + "        pill.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));\n"
+        + "        pill.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));\n"
+        + "        pill.click();\n"
+        + "        await sleep(800);\n"
+        + "        let clicked = false;\n"
+        + "        let chosen = '';\n"
+        + "        for (let depth = 0; depth < 6 && !clicked; depth++) {\n"
+        + "            const all = Array.from(document.querySelectorAll('[role=\"menuitem\"], [role=\"menuitemradio\"]'));\n"
+        + "            const leaves = all.filter((it) => it.getAttribute('aria-haspopup') !== 'menu');\n"
+        + "            for (const it of leaves) {\n"
+        + "                const t = norm(it.innerText);\n"
+        + "                if (t && t === target) {\n"
+        + "                    it.click();\n"
+        + "                    clicked = true;\n"
+        + "                    chosen = it.innerText;\n"
+        + "                    break;\n"
+        + "                }\n"
+        + "            }\n"
+        + "            if (clicked) break;\n"
+        + "            const trigs = all.filter((it) => it.getAttribute('aria-haspopup') === 'menu');\n"
+        + "            const trig = trigs.find((it) => {\n"
+        + "                const k = norm(it.innerText) + '|' + (it.getAttribute('aria-label') || '');\n"
+        + "                return !visited.has(k);\n"
+        + "            });\n"
+        + "            if (!trig) break;\n"
+        + "            visited.add(norm(trig.innerText) + '|' + (trig.getAttribute('aria-label') || ''));\n"
+        + "            trig.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));\n"
+        + "            trig.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));\n"
+        + "            trig.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));\n"
+        + "            trig.click();\n"
+        + "            await sleep(750);\n"
+        + "        }\n"
+        + "        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));\n"
+        + "        if (!clicked) {\n"
+        + "            window.__switch_model_status = 'error: model not found in menu';\n"
+        + "            return;\n"
+        + "        }\n"
+        + "        window.__switch_model_status = 'success:' + chosen;\n"
+        + "    } catch (e) {\n"
+        + "        window.__switch_model_status = 'error: ' + e.message;\n"
+        + "    }\n"
+        + "    })();\n"
+        + "    return true;\n"
+        + "}";
+
+    let start_res = call_mcp_tool(
+        config_path,
+        "evaluate_script",
+        serde_json::json!({ "function": js }),
+    )?;
+    let start_parsed = parse_script_result(&start_res)?;
+    if !start_parsed.as_bool().unwrap_or(false) {
+        return Err("Failed to initiate model switch script".to_string());
+    }
+
+    let mut wait_cycles = 0;
+    let mut status = String::from("pending");
+    while status == "pending" && wait_cycles < 60 {
+        thread::sleep(Duration::from_millis(200));
+        let check_res = call_mcp_tool(
+            config_path,
+            "evaluate_script",
+            serde_json::json!({ "function": "() => window.__switch_model_status || 'pending'" }),
+        )?;
+        if let Some(s) = parse_script_result(&check_res)
+            .ok()
+            .and_then(|p| p.as_str().map(|r| r.to_string()))
+        {
+            status = s;
+        }
+        wait_cycles += 1;
+    }
+
+    if status.starts_with("error:") {
+        return Err(format!("Model switch failed: {}", status));
+    }
+    if status == "pending" {
+        return Err("Timed out waiting for model switch".to_string());
+    }
+
+    if verbose {
+        println!("Model switched successfully ({})", status);
+    }
+
+    // Give the UI a moment to settle after switching models
+    thread::sleep(Duration::from_millis(500));
+
+    Ok(())
+}
+
 fn ensure_chatgpt_tab(
     config_path: &str,
     force_new: bool,
@@ -1891,6 +2023,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
         _ => {}
+    }
+
+    // Switch model if requested (before uploading attachments / typing the prompt)
+    if let Some(m) = &cli.model {
+        if let Err(e) = switch_model(&config_path, m, cli.verbose) {
+            eprintln!("Error switching model: {}", e);
+            std::process::exit(1);
+        }
     }
 
     // Upload any attached images/files before counting messages (so the UI is ready)


### PR DESCRIPTION
## 為什麼

`ask-chatgpt` 先前只能用 `--image` 夾帶圖片，無法上傳 PDF、Word、Excel 等文件；也無法在送出 prompt 前指定要使用的 ChatGPT 模型。這個 PR 補上這兩項能力，讓使用者從 CLI 就能附上各種本機檔案，並在開啟 ChatGPT 網頁後自動切換到指定模型或思考強度。

## 主要變更

### 1. `--file` 文件上傳（commit f0029ff）
- 新增 `--file <FILE>` 參數，可重複指定，支援 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等。
- 將原 `upload_images_to_chatgpt` 重構為 `upload_attachments_to_chatgpt`，同時處理 `--image` 與 `--file`。
- 新增 `mime_type_for_extension` 涵蓋圖片與多種文件類型。
- **繞過 ChatGPT CSP**：網頁的 CSP 會擋掉 `fetch(data:...)`，改為把 `{name, mime, base64}` 傳入 JS，在瀏覽器內用 `atob` → `Uint8Array` → `Blob` → `File` 解碼，再透過 `DataTransfer` 設到 `input[type="file"]` 並觸發 `change`。
- **順帶修 bug**：commit 19be9b7 把 `_version` 欄位宣告為 `bool` 並搭配 `ArgAction::Version` + `disable_version_flag=true`，導致 `_version` 變成必填、CLI 完全無法執行。改為 `()` 修復。

### 2. `--model` 模型切換（commit 93ae0a7）
- 新增 `--model <MODEL>` 參數，在登入檢查後、附件上傳前自動切換模型或思考強度。
- 新增 `switch_model()`：注入 async JS 驅動 composer pill 的 Radix 選單。
- 比對方式：`norm(text)`（小寫、去除 `-`/`.`/空格/底線），所以 `gpt-5.4`、`GPT-5.4`、`GPT 5 4` 都會 match。
- **Radix 重新渲染的因應**：選單每次開關都會重新 render，DOM element ref 會失效。因此用 stable key（`norm(text)|aria-label`）追蹤已拜訪的 submenu trigger，而非用 DOM node identity。
- submenu 開啟需 `pointerenter`/`pointermove`/`mouseover` 加 `.click()`，單純 pointer 事件不會展開子選單。
- 找不到模型時優雅失敗：`Model switch failed: error: model not found in menu`，不會送出 prompt。
- 移除開發期間臨時加入用來探查 DOM 的 `Eval` subcommand。

## 可用模型名稱（視帳號權限）
- **模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
- **思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`

## 瀏覽器實測結果
- `--file sample.txt`、`--file notes.md`、`--image red120.png` 皆成功上傳，ChatGPT 讀到內容。
- 同時 `--image` + `--file` 與連續兩個 `--file` + 兩個 `--image` 皆正常。
- `--model gpt-5.3 --new "請只回覆這五個字：模型切換成功"` → 切換成功，ChatGPT 回覆「模型切換成功」。
- `--model gpt-5.5`（submenu 內模型）與 `--model 超高`（思考等級 leaf）皆切換成功。
- `--model NonExistentModelXYZ` → 優雅失敗，未送出 prompt。

## 建置驗證
- `cargo build --release` 通過，無 warning。
- `cargo fmt --check` 通過。

## 文件
README.md、README.en.md、docs/quick-start.md 皆已更新 `--file` 與 `--model` 用法。