### PR TITLE
feat: 新增 Claude (claude.ai) provider 支援

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## 📌 專案概述
 
-`ask-bridge` 是一個基於 Rust 語言編寫的命令列工具，旨在透過 **Google Chrome** 的遠端除錯協定（Remote Debugging Protocol）來自動化操控網頁版的 **ChatGPT** 與 **Gemini**，並透過 MCP (Model Context Protocol) 與外部進行對接與問答。
+`ask-bridge` 是一個基於 Rust 語言編寫的命令列工具，旨在透過 **Google Chrome** 的遠端除錯協定（Remote Debugging Protocol）來自動化操控網頁版的 **ChatGPT**、**Gemini** 與 **Claude**，並透過 MCP (Model Context Protocol) 與外部進行對接與問答。
 
 ### ⚙️ 核心工作原理
 1. **Chrome 遠端除錯**：啟動一個監聽於連接埠 `9223` 的 Chrome 實例（提供專屬的 user-data-dir 設定檔目錄）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### 🚀 新增 (Added)
+- **Claude（claude.ai）provider 支援**：新增 `--provider claude`，透過 Chrome 自動化 claude.ai 網頁送出 prompt 並取回回覆，與 ChatGPT / Gemini 採相同架構。支援登入偵測（三態 `LoggedIn` / `LoggedOut` / `Unknown`）、分頁重用、`--new` 開新對話、Thread Link 輸出與 `-o` Markdown 檔案輸出。
+- Claude 支援 `--image` / `--file` 附件上傳（走既有 DataTransfer 路徑）與 `--model` 模型切換（如 `Sonnet`、`Opus`、`Haiku`，不分大小寫與標點，支援子選單走訪）。
+- Selector 依 claude.ai 實站校準：composer 以 `data-testid="chat-input"` 優先；回覆容器採 `.font-claude-response`（`data-is-streaming` 屬性僅掛在最後一則回覆容器，不適合用於訊息計數）。
+
 ---
 
 ## [0.2.1] - 2026-07-10

--- a/README.en.md
+++ b/README.en.md
@@ -1,21 +1,21 @@
 # Ask Bridge 🦀
 
-`ask-bridge` is a powerful, lightweight command-line tool written in **Rust** that automates ChatGPT or Gemini directly in your real Chrome browser. It uses the **Model Context Protocol (MCP)** and **Chrome DevTools Protocol (CDP)** via the embedded `doggy8088/mcp-cli` Rust library dependency and `chrome-devtools-mcp` to control Chrome, input prompts, click submit, and print the response back to your terminal. ChatGPT is the default when no global provider is configured; use `--provider gemini` or the global config file to switch to Gemini.
+`ask-bridge` is a powerful, lightweight command-line tool written in **Rust** that automates ChatGPT, Gemini or Claude directly in your real Chrome browser. It uses the **Model Context Protocol (MCP)** and **Chrome DevTools Protocol (CDP)** via the embedded `doggy8088/mcp-cli` Rust library dependency and `chrome-devtools-mcp` to control Chrome, input prompts, click submit, and print the response back to your terminal. ChatGPT is the default when no global provider is configured; use `--provider gemini`, `--provider claude`, or the global config file to switch providers.
 
 ## Design Intent
 
-The core purpose of `ask-bridge` is not to replace ChatGPT, Gemini, or any Coding Agent. It is to bridge them together. During software development, many AI-assisted tasks are exploratory: researching background information, summarizing documents, comparing options, digesting error messages, analyzing code snippets, drafting text, or clarifying uncertain technical questions. These tasks do not always need to be handled directly by the primary Coding Agent, and they do not always justify using the same agent budget that should be reserved for code editing, testing, refactoring, and integration work.
+The core purpose of `ask-bridge` is not to replace ChatGPT, Gemini, Claude, or any Coding Agent. It is to bridge them together. During software development, many AI-assisted tasks are exploratory: researching background information, summarizing documents, comparing options, digesting error messages, analyzing code snippets, drafting text, or clarifying uncertain technical questions. These tasks do not always need to be handled directly by the primary Coding Agent, and they do not always justify using the same agent budget that should be reserved for code editing, testing, refactoring, and integration work.
 
-With `ask-bridge`, a Coding Agent can delegate low-risk, exploratory, and research-oriented tasks to the ChatGPT or Gemini websites, then bring the website response back into the terminal or the next step of the local workflow. Because ChatGPT and Gemini website usage quotas are typically separate from Coding Agent execution quotas, `ask-bridge` gives developers a more flexible way to allocate AI resources: the primary agent can focus on understanding the repository, modifying code, running tests, and integrating results, while website-based AI handles background research, text processing, and candidate solution generation.
+With `ask-bridge`, a Coding Agent can delegate low-risk, exploratory, and research-oriented tasks to the ChatGPT, Gemini, or Claude websites, then bring the website response back into the terminal or the next step of the local workflow. Because ChatGPT, Gemini, and Claude website usage quotas are typically separate from Coding Agent execution quotas, `ask-bridge` gives developers a more flexible way to allocate AI resources: the primary agent can focus on understanding the repository, modifying code, running tests, and integrating results, while website-based AI handles background research, text processing, and candidate solution generation.
 
-In other words, `ask-bridge` is an external research bridge for AI Agents. It turns the manual workflow of switching to a browser, pasting a prompt, waiting for a response, and copying the result back into a command-line-driven automation capability. This lets an agent request help from ChatGPT or Gemini without leaving the local development workflow, then use the response as supporting context for its own judgment.
+In other words, `ask-bridge` is an external research bridge for AI Agents. It turns the manual workflow of switching to a browser, pasting a prompt, waiting for a response, and copying the result back into a command-line-driven automation capability. This lets an agent request help from ChatGPT, Gemini, or Claude without leaving the local development workflow, then use the response as supporting context for its own judgment.
 
 This tool is especially useful for:
 
 - Sending large documents, error messages, or code snippets to a website-based AI for summarization, comparison, or first-pass analysis.
 - Letting a Coding Agent outsource background research, alternative analysis, or checklist generation before implementation.
 - Moving AI tasks that do not directly modify project files out of the primary agent workflow.
-- Reusing existing ChatGPT or Gemini web accounts for interactive website features outside an API workflow.
+- Reusing existing ChatGPT, Gemini, or Claude web accounts for interactive website features outside an API workflow.
 
 `ask-bridge` does not guarantee that provider output is correct, and it should not replace local tests, official documentation checks, or human review. Its role is to reduce the operational cost of exploratory AI work and let the primary Coding Agent obtain external AI assistance with less friction.
 
@@ -29,7 +29,7 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 ## 🌟 Key Features
 
 - **🦀 100% Rust Core**: Extremely fast, lightweight, and compile-once, run-anywhere binary.
-- **Multi-provider support**: Choose ChatGPT or Gemini with `--provider chatgpt|gemini`.
+- **Multi-provider support**: Choose ChatGPT, Gemini, or Claude with `--provider chatgpt|gemini|claude`.
 - **Global provider config**: Set the default provider in `~/.config/ask-bridge/config.json`; CLI `--provider` overrides the config file.
 - **🌐 Real Browser Automation**: Directly interacts with Chrome on port `9223` (isolated debug profile).
 - **🔒 Persistent Login**: Uses a dedicated local profile directory (`~/.config/ask-bridge/chrome-profile`) so you never lose your login state.
@@ -37,8 +37,8 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 - **🌀 TUI Thinking Animation**: Displays a rotating spinner while waiting for the provider to reply, then clears it once output starts.
 - **🧠 Intelligent Tab Management**: Reuses existing provider tabs if open, focuses them, or opens new ones, avoiding tab clutter.
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask-bridge "summarize this"`).
-- **📎 Image & File Attachments**: Attach local images to ChatGPT with `--image`, or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`.
-- **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4` or Gemini `3.5 Flash`.
+- **📎 Image & File Attachments**: Attach local images with `--image` (supported on ChatGPT and Claude), or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`.
+- **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4`, Gemini `3.5 Flash`, or Claude `Sonnet`.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
 - **Version Info**: Use `-v` or `--version` to print the current version number.
 
@@ -112,7 +112,7 @@ The compiled binary will be located at `target/release/ask-bridge`.
 
 ### 4. Install the Agent Skill
 
-This repository provides an `ask-bridge` Agent Skill so Skills-compatible Coding Agents can use `ask-bridge` to delegate exploratory research, summarization, document analysis, or option comparison tasks to the ChatGPT or Gemini websites.
+This repository provides an `ask-bridge` Agent Skill so Skills-compatible Coding Agents can use `ask-bridge` to delegate exploratory research, summarization, document analysis, or option comparison tasks to the ChatGPT, Gemini, or Claude websites.
 
 Install it with `npx skills`; you do not need to copy the `skills/` directory manually:
 
@@ -138,23 +138,25 @@ Before sending prompts, you need to log in to the selected provider. ChatGPT is 
 ask-bridge login
 ```
 
-For Gemini:
+For Gemini or Claude:
 
 ```bash
 ask-bridge --provider gemini login
+ask-bridge --provider claude login
 ```
 
 - This will automatically launch Google Chrome with a dedicated, persistent debug profile.
-- Log in manually to the selected provider page, such as `https://chatgpt.com/` or `https://gemini.google.com/app`.
+- Log in manually to the selected provider page, such as `https://chatgpt.com/`, `https://gemini.google.com/app`, or `https://claude.ai/new`.
 - Once logged in, return to your terminal and press **`[Enter]`**.
 - The tool will verify your login status and save your profile. You only need to do this **once**!
 
 #### Global Provider Config
 
-To use Gemini by default when `--provider` is not specified:
+To use Gemini or Claude by default when `--provider` is not specified:
 
 ```bash
 ask-bridge config --provider gemini
+ask-bridge config --provider claude
 ```
 
 To switch the default back to ChatGPT:
@@ -182,6 +184,7 @@ Simply pass your prompt as an argument:
 ```bash
 ask-bridge "What is the difference between a struct and a tuple in Rust?"
 ask-bridge --provider gemini "What is the difference between a struct and a tuple in Rust?"
+ask-bridge --provider claude "What is the difference between a struct and a tuple in Rust?"
 ```
 
 - Chrome will open or focus on your selected provider tab.
@@ -264,18 +267,19 @@ Instead of piping file contents into the prompt, you can upload local files as a
 
 #### Attach images
 
-Use `--image` (repeatable) to attach one or more local images. This currently supports ChatGPT; Gemini image input is not enabled and exits with an explicit error when used with `--provider gemini`.
+Use `--image` (repeatable) to attach one or more local images. This currently supports ChatGPT and Claude; Gemini image input is not enabled and exits with an explicit error when used with `--provider gemini`.
 
 ```bash
 ask-bridge "Describe this image." --image screenshot.png
 ask-bridge "Compare these two images." --image v1.png --image v2.png
+ask-bridge --provider claude "Describe this image." --image screenshot.png
 ```
 
 Supported formats include PNG, JPEG, GIF, WebP, SVG, BMP, and more.
 
 #### Attach documents
 
-Use `--file` (repeatable) to attach documents such as PDF, Word, Excel, PowerPoint, plain text, Markdown, CSV, JSON, or source code. This flow supports both ChatGPT and Gemini.
+Use `--file` (repeatable) to attach documents such as PDF, Word, Excel, PowerPoint, plain text, Markdown, CSV, JSON, or source code. This flow supports ChatGPT, Gemini, and Claude.
 
 ```bash
 ask-bridge "Summarize this PDF." --file report.pdf
@@ -299,6 +303,8 @@ ask-bridge "Prove this math problem." --model o3
 ask-bridge "Quickly translate this." --model 即時
 ask-bridge --provider gemini "Introduce Rust in a few sentences." --model "3.5 Flash"
 ask-bridge --provider gemini "Introduce Rust in a few sentences." --model "3.1 Pro"
+ask-bridge --provider claude "Introduce Rust in a few sentences." --model Sonnet
+ask-bridge --provider claude "Prove this math problem." --model Opus
 ```
 
 Available model names (depending on your account entitlements and provider UI):
@@ -306,6 +312,7 @@ Available model names (depending on your account entitlements and provider UI):
 - **ChatGPT models**: `GPT-5.5`, `GPT-5.4`, `GPT-5.3`, `o3`
 - **ChatGPT thinking levels**: `智慧`, `即時`, `中等`, `高`, `超高`, `專業`
 - **Gemini modes**: `3.5 Flash`, `3.1 Flash-Lite`, `3.1 Pro`
+- **Claude models**: `Sonnet`, `Opus`, `Haiku` (actual names depend on the claude.ai menu and your plan)
 
 > If the requested name is not found in the menu, `ask-bridge` reports `Model switch failed: error: model not found in menu` and aborts without submitting the prompt.
 
@@ -316,6 +323,7 @@ To quickly launch the browser and open the selected provider without sending any
 ```bash
 ask-bridge open
 ask-bridge --provider gemini open
+ask-bridge --provider claude open
 ```
 
 ### 11. Close the Browser Instance

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Ask Bridge 🦀
 
-`ask-bridge` 是以 Rust 撰寫的輕量命令列工具，可透過真實 Chrome 瀏覽器自動操作 ChatGPT 與 Gemini。它使用 Model Context Protocol MCP 與 Chrome DevTools Protocol CDP，並透過內建的 `doggy8088/mcp-cli` Rust library dependency 搭配 `chrome-devtools-mcp` 控制 Chrome、輸入 prompt、送出訊息，並將回覆輸出到終端機。未設定全域 provider 時預設使用 ChatGPT，可用 `--provider gemini` 或全域設定檔切換到 Gemini。
+`ask-bridge` 是以 Rust 撰寫的輕量命令列工具，可透過真實 Chrome 瀏覽器自動操作 ChatGPT、Gemini 與 Claude。它使用 Model Context Protocol MCP 與 Chrome DevTools Protocol CDP，並透過內建的 `doggy8088/mcp-cli` Rust library dependency 搭配 `chrome-devtools-mcp` 控制 Chrome、輸入 prompt、送出訊息，並將回覆輸出到終端機。未設定全域 provider 時預設使用 ChatGPT，可用 `--provider gemini`、`--provider claude` 或全域設定檔切換 provider。
 
 ## 設計意圖
 
-`ask-bridge` 的核心目的不是取代 ChatGPT、Gemini 或任何 Coding Agent，而是把它們橋接在一起。開發過程中常會出現大量探索性的 AI 需求，例如查資料、整理文件、比較方案、摘要錯誤訊息、分析程式片段、產生初稿或協助釐清不確定的技術問題。這類任務通常不一定需要由主要 Coding Agent 親自完成，也不一定值得消耗與程式碼編輯、測試、重構等高價值工作相同的 agent 額度。
+`ask-bridge` 的核心目的不是取代 ChatGPT、Gemini、Claude 或任何 Coding Agent，而是把它們橋接在一起。開發過程中常會出現大量探索性的 AI 需求，例如查資料、整理文件、比較方案、摘要錯誤訊息、分析程式片段、產生初稿或協助釐清不確定的技術問題。這類任務通常不一定需要由主要 Coding Agent 親自完成，也不一定值得消耗與程式碼編輯、測試、重構等高價值工作相同的 agent 額度。
 
-透過 `ask-bridge`，Coding Agent 可以把這些低風險、探索性、可委派的研究工作轉交給 ChatGPT 或 Gemini 網站處理，再把網站回覆取回終端機或後續工作流程中。由於 ChatGPT、Gemini 網站的使用額度與 Coding Agent 的執行額度通常分開計算，`ask-bridge` 可以讓開發者更有彈性地分配 AI 資源：主要 agent 專注在理解專案、修改程式、執行測試與整合結果；網站型 AI 則負責背景研究、文字處理與候選方案產出。
+透過 `ask-bridge`，Coding Agent 可以把這些低風險、探索性、可委派的研究工作轉交給 ChatGPT、Gemini 或 Claude 網站處理，再把網站回覆取回終端機或後續工作流程中。由於 ChatGPT、Gemini、Claude 網站的使用額度與 Coding Agent 的執行額度通常分開計算，`ask-bridge` 可以讓開發者更有彈性地分配 AI 資源：主要 agent 專注在理解專案、修改程式、執行測試與整合結果；網站型 AI 則負責背景研究、文字處理與候選方案產出。
 
-換句話說，`ask-bridge` 是一個給 AI Agent 使用的外部研究橋接器：它把原本需要人類切換瀏覽器、貼上 prompt、等待回覆、再複製結果的流程，包裝成可由命令列驅動的自動化能力。這讓 agent 可以在不離開本機工作流程的情況下，自主向 ChatGPT 或 Gemini 發出請求，取得輔助資訊，並將其納入後續判斷。
+換句話說，`ask-bridge` 是一個給 AI Agent 使用的外部研究橋接器：它把原本需要人類切換瀏覽器、貼上 prompt、等待回覆、再複製結果的流程，包裝成可由命令列驅動的自動化能力。這讓 agent 可以在不離開本機工作流程的情況下，自主向 ChatGPT、Gemini 或 Claude 發出請求，取得輔助資訊，並將其納入後續判斷。
 
 此工具特別適合：
 
 - 將大型文件、錯誤訊息或程式片段交給網站型 AI 做摘要、比對或初步分析。
 - 讓 Coding Agent 在實作前先委外蒐集背景資料、整理替代方案或產生檢查清單。
 - 把不需要直接修改專案檔案的 AI 任務移出主要 agent 執行流程。
-- 利用既有 ChatGPT 或 Gemini 網頁帳號的能力，處理 API 以外的互動式網站功能。
+- 利用既有 ChatGPT、Gemini 或 Claude 網頁帳號的能力，處理 API 以外的互動式網站功能。
 
 `ask-bridge` 不保證網站 provider 的輸出一定正確，也不應取代本機測試、官方文件查證或人工審查。它的定位是降低探索性 AI 工作的操作成本，讓主要 Coding Agent 能以更低摩擦取得外部 AI 協助。
 
@@ -28,7 +28,7 @@
 ## 主要功能
 
 - **100% Rust 核心**：快速、輕量，編譯後即可執行。
-- **多 provider 支援**：使用 `--provider chatgpt|gemini` 選擇 ChatGPT 或 Gemini。
+- **多 provider 支援**：使用 `--provider chatgpt|gemini|claude` 選擇 ChatGPT、Gemini 或 Claude。
 - **全域 provider 設定**：可在 `~/.config/ask-bridge/config.json` 指定預設 provider，CLI 的 `--provider` 會覆蓋設定檔。
 - **真實瀏覽器自動化**：直接控制監聽 `9223` port 的 Chrome debug profile。
 - **持久登入狀態**：使用專屬本機 profile 目錄 `~/.config/ask-bridge/chrome-profile`，避免重複登入。
@@ -36,8 +36,8 @@
 - **思考動畫**：等待 provider 回覆時，在終端機顯示旋轉 spinner，開始輸出內容後自動清除。
 - **智慧分頁管理**：可重用既有 provider 分頁、聚焦分頁，或開啟新分頁，避免分頁過度增加。
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask-bridge "summarize this"`。
-- **圖片與文件上傳**：可透過 `--image` 附上 ChatGPT 圖片，或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入。
-- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，或 Gemini 的 `3.5 Flash`、`3.1 Pro`）。
+- **圖片與文件上傳**：可透過 `--image` 附上圖片（支援 ChatGPT 與 Claude），或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入。
+- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，Gemini 的 `3.5 Flash`、`3.1 Pro`，或 Claude 的 `Sonnet`、`Opus`）。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
 - **版本資訊**：使用 `-v` 或 `--version` 顯示目前版本號。
 
@@ -107,7 +107,7 @@ cargo build --release
 
 ### 4. 安裝 Agent Skill
 
-本專案提供 `ask-bridge` Agent Skill，讓支援 Skills 的 Coding Agent 可以在適合的情境下，自主使用 `ask-bridge` 將探索性研究、摘要、文件分析或方案比較等工作委派給 ChatGPT 或 Gemini 網站。
+本專案提供 `ask-bridge` Agent Skill，讓支援 Skills 的 Coding Agent 可以在適合的情境下，自主使用 `ask-bridge` 將探索性研究、摘要、文件分析或方案比較等工作委派給 ChatGPT、Gemini 或 Claude 網站。
 
 請使用 `npx skills` 安裝，不需要手動複製 `skills/` 目錄：
 
@@ -131,16 +131,17 @@ npx skills add doggy8088/ask-bridge --skill ask-bridge --agent codex --global
 ask-bridge login
 ```
 
-若要登入 Gemini：
+若要登入 Gemini 或 Claude：
 
 ```bash
 ask-bridge --provider gemini login
+ask-bridge --provider claude login
 ```
 
 此命令會：
 
 - 使用專屬且持久化的 debug profile 啟動 Google Chrome。
-- 開啟所選 provider 頁面，例如 `https://chatgpt.com/` 或 `https://gemini.google.com/app`。
+- 開啟所選 provider 頁面，例如 `https://chatgpt.com/`、`https://gemini.google.com/app` 或 `https://claude.ai/new`。
 - 等待你手動登入帳號。
 - 在你回到終端機按 Enter 後，驗證登入狀態並保存 profile。
 
@@ -148,10 +149,11 @@ ask-bridge --provider gemini login
 
 #### 全域 provider 設定
 
-若希望未指定 `--provider` 時預設使用 Gemini，可用 `ask-bridge config` 指定：
+若希望未指定 `--provider` 時預設使用 Gemini 或 Claude，可用 `ask-bridge config` 指定：
 
 ```bash
 ask-bridge config --provider gemini
+ask-bridge config --provider claude
 ```
 
 若要改回 ChatGPT：
@@ -179,6 +181,7 @@ ask-bridge --provider chatgpt "請摘要這段內容。"
 ```bash
 ask-bridge "Rust struct 和 tuple 有什麼差異？"
 ask-bridge --provider gemini "Rust struct 和 tuple 有什麼差異？"
+ask-bridge --provider claude "Rust struct 和 tuple 有什麼差異？"
 ```
 
 執行後：
@@ -263,18 +266,19 @@ cat src/main.rs | ask-bridge "這段 Rust code 有記憶體洩漏風險嗎？"
 
 #### 附上圖片
 
-使用 `--image` 附上一或多張本機圖片（可重複指定）。此功能目前支援 ChatGPT；Gemini 圖片輸入尚未支援，搭配 `--provider gemini` 使用會立即回報錯誤。
+使用 `--image` 附上一或多張本機圖片（可重複指定）。此功能目前支援 ChatGPT 與 Claude；Gemini 圖片輸入尚未支援，搭配 `--provider gemini` 使用會立即回報錯誤。
 
 ```bash
 ask-bridge "請描述這張圖片的內容。" --image screenshot.png
 ask-bridge "比較這兩張圖的差異。" --image v1.png --image v2.png
+ask-bridge --provider claude "請描述這張圖片的內容。" --image screenshot.png
 ```
 
 支援的格式包含 PNG、JPEG、GIF、WebP、SVG、BMP 等。
 
 #### 附上文件
 
-使用 `--file` 附上一或多份本機文件（可重複指定），例如 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等。ChatGPT 與 Gemini 都支援此流程。
+使用 `--file` 附上一或多份本機文件（可重複指定），例如 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等。ChatGPT、Gemini 與 Claude 都支援此流程。
 
 ```bash
 ask-bridge "請摘要這份 PDF 的重點。" --file report.pdf
@@ -302,6 +306,8 @@ ask-bridge "證明這個數學問題。" --model o3
 ask-bridge "快速翻譯這段話。" --model 即時
 ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.5 Flash"
 ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.1 Pro"
+ask-bridge --provider claude "用幾句話介紹 Rust。" --model Sonnet
+ask-bridge --provider claude "證明這個數學問題。" --model Opus
 ```
 
 可用的模型名稱（視帳號權限與 provider UI 而定）：
@@ -309,6 +315,7 @@ ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.1 Pro"
 - **ChatGPT 模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
 - **ChatGPT 思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
 - **Gemini 模式**：`3.5 Flash`、`3.1 Flash-Lite`、`3.1 Pro`
+- **Claude 模型**：`Sonnet`、`Opus`、`Haiku`（實際名稱依 claude.ai 選單與帳號方案而定）
 
 > 若指定的名稱在選單中找不到，`ask-bridge` 會回報 `Model switch failed: error: model not found in menu` 並中止，不會送出 prompt。
 
@@ -319,6 +326,7 @@ ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.1 Pro"
 ```bash
 ask-bridge open
 ask-bridge --provider gemini open
+ask-bridge --provider claude open
 ```
 
 ### 11. 關閉瀏覽器 instance

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,6 @@
 # 快速開始
 
-本文件說明如何安裝 `ask-bridge`，並透過 Chrome 自動操作 ChatGPT 或 Gemini。未設定全域 provider 時預設為 ChatGPT，可用 `--provider gemini` 或全域設定檔切換。
+本文件說明如何安裝 `ask-bridge`，並透過 Chrome 自動操作 ChatGPT、Gemini 或 Claude。未設定全域 provider 時預設為 ChatGPT，可用 `--provider gemini`、`--provider claude` 或全域設定檔切換。
 
 ## 前置需求
 
@@ -51,12 +51,21 @@ ask-bridge --provider gemini login
 
 在瀏覽器視窗登入 Gemini 後，回到終端機按 Enter。
 
+若要登入 Claude：
+
+```sh
+ask-bridge --provider claude login
+```
+
+在瀏覽器視窗登入 claude.ai 後，回到終端機按 Enter。
+
 ## 全域 provider 設定
 
-若希望未指定 `--provider` 時預設使用 Gemini，可執行：
+若希望未指定 `--provider` 時預設使用 Gemini 或 Claude，可執行：
 
 ```sh
 ask-bridge config --provider gemini
+ask-bridge config --provider claude
 ```
 
 若要改回 ChatGPT：
@@ -76,6 +85,7 @@ ask-bridge config --provider chatgpt
 ```sh
 ask-bridge "用一段話解釋 Rust ownership。"
 ask-bridge --provider gemini "用一段話解釋 Rust ownership。"
+ask-bridge --provider claude "用一段話解釋 Rust ownership。"
 ```
 
 一般提問預設會使用 headless Chrome，並把所選 provider 的回覆輸出到終端機。
@@ -114,11 +124,11 @@ cat README.md | ask-bridge "摘要這份文件。"
 
 ## 附上圖片或文件
 
-`ask-bridge` 支援把本機檔案當作附件直接上傳給所選 provider，不必透過 pipe 把內容塞進 prompt。Gemini 目前支援 `--file` 文件附件；`--image` 圖片輸入目前僅支援 ChatGPT。
+`ask-bridge` 支援把本機檔案當作附件直接上傳給所選 provider，不必透過 pipe 把內容塞進 prompt。Gemini 目前支援 `--file` 文件附件；`--image` 圖片輸入目前支援 ChatGPT 與 Claude。
 
 ### 附上圖片
 
-使用 `--image`（可重複指定）。此功能目前僅支援 ChatGPT；搭配 `--provider gemini` 使用會立即回報錯誤。
+使用 `--image`（可重複指定）。此功能目前支援 ChatGPT 與 Claude；搭配 `--provider gemini` 使用會立即回報錯誤。
 
 ```sh
 ask-bridge "請描述這張圖片。" --image screenshot.png
@@ -150,6 +160,7 @@ ask-bridge "用幾句話介紹 Rust。" --model GPT-5.4
 ask-bridge "證明這個數學問題。" --model o3
 ask-bridge "快速翻譯這段話。" --model 即時
 ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.5 Flash"
+ask-bridge --provider claude "用幾句話介紹 Rust。" --model Sonnet
 ```
 
 可用名稱（視帳號權限與 provider UI）：
@@ -157,6 +168,7 @@ ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.5 Flash"
 - **ChatGPT 模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
 - **ChatGPT 思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
 - **Gemini 模式**：`3.5 Flash`、`3.1 Flash-Lite`、`3.1 Pro`
+- **Claude 模型**：`Sonnet`、`Opus`、`Haiku`（實際名稱依 claude.ai 選單與帳號方案而定）
 
 ## 關閉瀏覽器 instance
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ask-bridge",
   "version": "0.2.1",
-  "description": "Automate ChatGPT or Gemini from the command line through Chrome.",
+  "description": "Automate ChatGPT, Gemini or Claude from the command line through Chrome.",
   "bin": {
     "ask-bridge": "npm/cli.cjs",
     "ask": "npm/cli.cjs"
@@ -25,6 +25,7 @@
   "keywords": [
     "chatgpt",
     "gemini",
+    "claude",
     "chrome",
     "rust",
     "cli"

--- a/skills/ask-bridge/SKILL.md
+++ b/skills/ask-bridge/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: ask-bridge
-description: "完整使用 ask-bridge CLI 的 Agent Skill。使用 ask-bridge 將低風險、探索性 AI 研究、摘要、文件分析、程式片段分析、錯誤訊息整理、方案比較、初稿產出或可委派的背景調查交給 ChatGPT 或 Gemini 網站。當 Codex 需要透過本機 ask-bridge 命令呼叫網站型 AI、利用 ChatGPT/Gemini 網頁額度、附加檔案或圖片、切換模型、取回回覆、下載生成圖片、管理瀏覽器 session、或查詢 ask-bridge 所有參數與子命令用法時使用。"
+description: "完整使用 ask-bridge CLI 的 Agent Skill。使用 ask-bridge 將低風險、探索性 AI 研究、摘要、文件分析、程式片段分析、錯誤訊息整理、方案比較、初稿產出或可委派的背景調查交給 ChatGPT、Gemini 或 Claude 網站。當 Codex 需要透過本機 ask-bridge 命令呼叫網站型 AI、利用 ChatGPT/Gemini/Claude 網頁額度、附加檔案或圖片、切換模型、取回回覆、下載生成圖片、管理瀏覽器 session、或查詢 ask-bridge 所有參數與子命令用法時使用。"
 ---
 
 # Ask Bridge
 
 ## 核心原則
 
-使用 `ask-bridge` 把低風險、探索性、可委派的 AI 任務交給 ChatGPT 或 Gemini 網站處理，再將回覆作為本機工作流程的參考輸入。不要把 provider 回覆視為事實來源、測試結果或已完成的程式碼變更。
+使用 `ask-bridge` 把低風險、探索性、可委派的 AI 任務交給 ChatGPT、Gemini 或 Claude 網站處理，再將回覆作為本機工作流程的參考輸入。不要把 provider 回覆視為事實來源、測試結果或已完成的程式碼變更。
 
 優先把主要 Coding Agent 保留給下列工作：讀取專案脈絡、修改檔案、執行測試、驗證行為、整合結論。把 `ask-bridge` 用於背景研究、摘要、候選方案、初稿與輔助分析。
 
@@ -65,9 +65,17 @@ ask-bridge -v
 }
 ```
 
+或：
+
+```json
+{
+  "provider": "claude"
+}
+```
+
 provider 優先序：
 
-1. CLI `--provider chatgpt|gemini`
+1. CLI `--provider chatgpt|gemini|claude`
 2. `~/.config/ask-bridge/config.json` 的 `provider`
 3. 內建預設 `chatgpt`
 
@@ -75,6 +83,7 @@ provider 優先序：
 
 ```sh
 ask-bridge config --provider gemini
+ask-bridge config --provider claude
 ```
 
 若要改回 ChatGPT：
@@ -100,6 +109,7 @@ ask-bridge --provider chatgpt '請摘要這段內容。'
 ```sh
 ask-bridge login
 ask-bridge --provider gemini login
+ask-bridge --provider claude login
 ask-bridge login --provider gemini
 ```
 
@@ -152,18 +162,18 @@ prompt + "\n\n" + stdin
 | 參數 | 用途 | 用法重點 |
 |---|---|---|
 | `[PROMPT]` | 要送給 provider 的文字 prompt | 可省略；若 stdin 有內容則使用 stdin；若兩者都有，會以兩個換行串接 |
-| `-p`, `--provider <PROVIDER>` | 選擇 provider | 可用 `chatgpt` 或 `gemini`；此為 global option，可放在子命令前後；優先權高於全域設定檔 |
+| `-p`, `--provider <PROVIDER>` | 選擇 provider | 可用 `chatgpt`、`gemini` 或 `claude`；此為 global option，可放在子命令前後；優先權高於全域設定檔 |
 | `--headless[=<HEADLESS>]` | 控制 Chrome 是否 headless | 預設 `true`；要顯示瀏覽器請用 `--headless=false`；不要寫成 `--headless false` |
 | `--new` | 開啟全新 provider 對話 | 會開新分頁並清理同 provider 舊分頁；用於隔離上下文 |
 | `-v`, `-V`, `--version` | 顯示版本 | `-V` 是原始碼中定義的短別名；文件與一般操作優先用 `-v` 或 `--version` |
 | `--verbose` | 顯示瀏覽器自動化流程 | 用於診斷 provider UI、登入、上傳、模型切換或等待回覆問題 |
 | `-o`, `--output <FILE>` | 將最終 Markdown 回覆寫入檔案 | 同時仍會在終端機輸出渲染結果；適合保留研究紀錄 |
 | `-i`, `--image-output <IMAGE_PATH>` | 下載 provider 回覆中的生成圖片 | 可指定資料夾或檔案路徑；可搭配一般 prompt、`get` 或 `open <url>` |
-| `--image <IMAGE_FILE>` | 附加圖片檔，可重複指定 | 目前只支援 ChatGPT；搭配 Gemini 會失敗 |
-| `--file <FILE>` | 附加文件檔，可重複指定 | 支援 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等；ChatGPT 與 Gemini 都可用 |
+| `--image <IMAGE_FILE>` | 附加圖片檔，可重複指定 | 支援 ChatGPT 與 Claude；搭配 Gemini 會失敗 |
+| `--file <FILE>` | 附加文件檔，可重複指定 | 支援 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等；ChatGPT、Gemini 與 Claude 都可用 |
 | `--model <MODEL>` | 送出 prompt 前切換模型 | 比對不分大小寫與標點；模型名稱取決於 provider UI 與帳號權限 |
 | `-h`, `--help` | 顯示 help | 可用 `ask-bridge --help` 或 `ask-bridge help <COMMAND>` |
-| `config` | 設定或顯示全域預設 provider | 使用 `ask-bridge config --provider <chatgpt|gemini>` |
+| `config` | 設定或顯示全域預設 provider | 使用 `ask-bridge config --provider <chatgpt|gemini|claude>` |
 
 ## Provider 選擇
 
@@ -175,18 +185,21 @@ ask-bridge --provider chatgpt '請分析這段程式碼的風險。'
 ask-bridge -p chatgpt '請整理這份文件的待辦。'
 ```
 
-使用 Gemini 時明確指定 provider：
+使用 Gemini 或 Claude 時明確指定 provider：
 
 ```sh
 ask-bridge --provider gemini '請比較這三個實作方向的風險與取捨。'
 ask-bridge -p gemini '請摘要這份文件。' --file notes.md
+ask-bridge --provider claude '請初步分析這段程式碼的風險。'
+ask-bridge -p claude '請摘要這份文件。' --file notes.md
 ```
 
 選擇原則：
 
 - 未指定 `--provider` 時，先依全域設定檔選擇 provider；設定檔不存在時使用 ChatGPT。
-- 使用 ChatGPT 作為未設定時的預設 provider，尤其是需要圖片輸入時。
+- 使用 ChatGPT 作為未設定時的預設 provider。
 - 使用 Gemini 做替代觀點、快速摘要或使用者明確要求 Gemini 時。
+- 使用 Claude 做程式碼分析、長文摘要、替代觀點或使用者明確要求 Claude 時；Claude 也支援 `--image` 圖片輸入。
 - 若 provider 失敗，可在不增加風險的情況下改用另一個 provider 一次。
 - 不要硬編不存在的模型名稱；只有使用者指定或專案文件明確列出時才使用 `--model`。
 
@@ -237,14 +250,15 @@ ask-bridge '請比較這兩份文件的差異。' --file old.md --file new.md
 ask-bridge --provider gemini '請摘要這份 PDF。' --file report.pdf
 ```
 
-對圖片使用 `--image`，且目前只用於 ChatGPT：
+對圖片使用 `--image`，目前支援 ChatGPT 與 Claude：
 
 ```sh
 ask-bridge '請描述這張截圖中的 UI 問題，並列出可能的 CSS 原因。' --image screenshot.png
 ask-bridge '請比較這兩張圖的差異。' --image before.png --image after.png
+ask-bridge --provider claude '請描述這張截圖中的 UI 問題。' --image screenshot.png
 ```
 
-同時附加圖片與文件時，使用 ChatGPT：
+同時附加圖片與文件時，使用 ChatGPT 或 Claude：
 
 ```sh
 ask-bridge '請對照設計圖與規格文件，列出不一致處。' --image design.png --file spec.md
@@ -282,6 +296,8 @@ ask-bridge '證明這個數學問題。' --model o3
 ask-bridge '快速翻譯這段話。' --model 即時
 ask-bridge --provider gemini '用幾句話介紹 Rust。' --model '3.5 Flash'
 ask-bridge --provider gemini '用幾句話介紹 Rust。' --model '3.1 Pro'
+ask-bridge --provider claude '用幾句話介紹 Rust。' --model Sonnet
+ask-bridge --provider claude '證明這個數學問題。' --model Opus
 ```
 
 模型比對不分大小寫與標點符號。若切換失敗，移除 `--model` 或改用 provider 預設模型，不要猜測替代模型名稱。
@@ -315,7 +331,7 @@ ask-bridge close
 
 | 子命令 | 用途 | 範例 |
 |---|---|---|
-| `login` | 開啟 provider 並等待使用者手動登入 | `ask-bridge login`、`ask-bridge --provider gemini login` |
+| `login` | 開啟 provider 並等待使用者手動登入 | `ask-bridge login`、`ask-bridge --provider gemini login`、`ask-bridge --provider claude login` |
 | `close` | 關閉 ask-bridge 管理的 Chrome instance | `ask-bridge close` |
 | `help` | 顯示 help | `ask-bridge help`、`ask-bridge help login` |
 
@@ -352,7 +368,7 @@ ask-bridge dump --verbose
 ask-bridge screenshot --headless=false
 ```
 
-Gemini 圖片輸入不支援時，改用 ChatGPT 或改以文字描述圖片內容。不要把同一個失敗命令無限制重試。
+Gemini 圖片輸入不支援時，改用 ChatGPT 或 Claude，或改以文字描述圖片內容。不要把同一個失敗命令無限制重試。
 
 模型切換失敗時，移除 `--model` 或改用 provider 預設模型，不要猜測替代模型名稱。
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,8 @@ impl Provider {
             }
             Provider::Claude => {
                 r#"() => {
-                    return document.querySelector('div[contenteditable="true"].ProseMirror') !== null ||
-                           document.querySelector('fieldset [contenteditable="true"]') !== null ||
+                    return document.querySelector('div[contenteditable="true"][data-testid="chat-input"]') !== null ||
+                           document.querySelector('div[contenteditable="true"].ProseMirror') !== null ||
                            document.querySelector('[data-testid="login-with-google"]') !== null ||
                            window.location.pathname.startsWith('/login') ||
                            /Sign in|登入/.test(document.body.innerText || '');
@@ -208,8 +208,8 @@ impl Provider {
             }
             Provider::Claude => {
                 r#"() => {
-                    const composer = document.querySelector('div[contenteditable="true"].ProseMirror') ||
-                        document.querySelector('fieldset [contenteditable="true"]');
+                    const composer = document.querySelector('div[contenteditable="true"][data-testid="chat-input"]') ||
+                        document.querySelector('div[contenteditable="true"].ProseMirror');
                     const loginIndicator = document.querySelector('[data-testid="login-with-google"]') !== null ||
                         window.location.pathname.startsWith('/login');
                     return Boolean(composer) && !loginIndicator;
@@ -222,7 +222,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "[data-message-author-role=\"assistant\"], .agent-turn",
             Provider::Gemini => "model-response",
-            Provider::Claude => "div[data-is-streaming], .font-claude-message",
+            Provider::Claude => ".font-claude-response",
         }
     }
 
@@ -232,7 +232,7 @@ impl Provider {
                 "[data-message-author-role=\"assistant\"], .agent-turn, model-response, .model-response, [data-test-id*=\"response\"], [data-testid*=\"response\"]"
             }
             Provider::Gemini => "model-response",
-            Provider::Claude => "div[data-is-streaming], .font-claude-message",
+            Provider::Claude => ".font-claude-response",
         }
     }
 
@@ -242,7 +242,7 @@ impl Provider {
             Provider::Gemini => {
                 "message-content, .markdown, structured-content-container.model-response-text"
             }
-            Provider::Claude => ".font-claude-message, .standard-markdown",
+            Provider::Claude => ".standard-markdown, .font-claude-response-body",
         }
     }
 
@@ -258,9 +258,9 @@ impl Provider {
             }
             Provider::Claude => {
                 r#"[
+                    "div[contenteditable=\"true\"][data-testid=\"chat-input\"]",
                     "div[contenteditable=\"true\"].ProseMirror",
-                    "div[aria-label*=\"Claude\"][contenteditable=\"true\"]",
-                    "fieldset [contenteditable=\"true\"]"
+                    "div[aria-label*=\"Claude\"][contenteditable=\"true\"]"
                 ]"#
             }
         }
@@ -2027,7 +2027,7 @@ fn click_latest_copy_button(config_path: &str, provider: Provider) -> Result<(),
                     if (el.closest('pre, code, [class*="code"], [data-testid*="code"]')) return -1;
                     if (/copy-turn-action-button/i.test(label)) return 100;
                     if (/response|回應|回答|reply/i.test(label)) return 90;
-                    if (el.closest('model-response, response-container, [data-message-author-role="assistant"], .agent-turn, [data-is-streaming], .font-claude-message')) return 50;
+                    if (el.closest('model-response, response-container, [data-message-author-role="assistant"], .agent-turn, [data-is-streaming], .font-claude-response')) return 50;
                     return 10;
                 };
                 const messages = Array.from(document.querySelectorAll(__RESPONSE_SELECTOR__));

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ enum Provider {
     ChatGpt,
     #[value(name = "gemini")]
     Gemini,
+    #[value(name = "claude")]
+    Claude,
 }
 
 impl Provider {
@@ -58,6 +60,7 @@ impl Provider {
         match value.trim().to_ascii_lowercase().as_str() {
             "chatgpt" | "chat-gpt" | "chat_gpt" => Some(Provider::ChatGpt),
             "gemini" => Some(Provider::Gemini),
+            "claude" | "claude-ai" | "claude_ai" | "claudeai" => Some(Provider::Claude),
             _ => None,
         }
     }
@@ -66,6 +69,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "ChatGPT",
             Provider::Gemini => "Gemini",
+            Provider::Claude => "Claude",
         }
     }
 
@@ -73,6 +77,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "https://chatgpt.com/",
             Provider::Gemini => "https://gemini.google.com/app",
+            Provider::Claude => "https://claude.ai/new",
         }
     }
 
@@ -80,11 +85,12 @@ impl Provider {
         match self {
             Provider::ChatGpt => url.contains("chatgpt.com"),
             Provider::Gemini => url.contains("gemini.google.com"),
+            Provider::Claude => url.contains("claude.ai"),
         }
     }
 
     fn from_url(url: &str) -> Option<Self> {
-        [Provider::ChatGpt, Provider::Gemini]
+        [Provider::ChatGpt, Provider::Gemini, Provider::Claude]
             .into_iter()
             .find(|provider| provider.owns_url(url))
     }
@@ -98,6 +104,15 @@ impl Provider {
                            document.querySelector('rich-textarea [contenteditable="true"]') !== null ||
                            document.querySelector('.ql-editor[contenteditable="true"]') !== null ||
                            document.querySelector('a[href*="accounts.google.com"]') !== null ||
+                           /Sign in|登入/.test(document.body.innerText || '');
+                }"#
+            }
+            Provider::Claude => {
+                r#"() => {
+                    return document.querySelector('div[contenteditable="true"].ProseMirror') !== null ||
+                           document.querySelector('fieldset [contenteditable="true"]') !== null ||
+                           document.querySelector('[data-testid="login-with-google"]') !== null ||
+                           window.location.pathname.startsWith('/login') ||
                            /Sign in|登入/.test(document.body.innerText || '');
                 }"#
             }
@@ -191,6 +206,15 @@ impl Provider {
                     };
                 }"#
             }
+            Provider::Claude => {
+                r#"() => {
+                    const composer = document.querySelector('div[contenteditable="true"].ProseMirror') ||
+                        document.querySelector('fieldset [contenteditable="true"]');
+                    const loginIndicator = document.querySelector('[data-testid="login-with-google"]') !== null ||
+                        window.location.pathname.startsWith('/login');
+                    return Boolean(composer) && !loginIndicator;
+                }"#
+            }
         }
     }
 
@@ -198,6 +222,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "[data-message-author-role=\"assistant\"], .agent-turn",
             Provider::Gemini => "model-response",
+            Provider::Claude => "div[data-is-streaming], .font-claude-message",
         }
     }
 
@@ -207,6 +232,7 @@ impl Provider {
                 "[data-message-author-role=\"assistant\"], .agent-turn, model-response, .model-response, [data-test-id*=\"response\"], [data-testid*=\"response\"]"
             }
             Provider::Gemini => "model-response",
+            Provider::Claude => "div[data-is-streaming], .font-claude-message",
         }
     }
 
@@ -216,6 +242,7 @@ impl Provider {
             Provider::Gemini => {
                 "message-content, .markdown, structured-content-container.model-response-text"
             }
+            Provider::Claude => ".font-claude-message, .standard-markdown",
         }
     }
 
@@ -227,6 +254,13 @@ impl Provider {
                     "div[role=\"textbox\"][aria-label*=\"Gemini\"]",
                     "rich-textarea [contenteditable=\"true\"]",
                     ".ql-editor[contenteditable=\"true\"]"
+                ]"#
+            }
+            Provider::Claude => {
+                r#"[
+                    "div[contenteditable=\"true\"].ProseMirror",
+                    "div[aria-label*=\"Claude\"][contenteditable=\"true\"]",
+                    "fieldset [contenteditable=\"true\"]"
                 ]"#
             }
         }
@@ -252,6 +286,13 @@ impl Provider {
                     "button[aria-label*=\"提交\"]"
                 ]"#
             }
+            Provider::Claude => {
+                r#"[
+                    "button[aria-label=\"Send message\"]",
+                    "button[aria-label*=\"Send\"]",
+                    "button[aria-label*=\"傳送\"]"
+                ]"#
+            }
         }
     }
 
@@ -271,6 +312,13 @@ impl Provider {
                     "button[aria-label*=\"停止\"]"
                 ]"#
             }
+            Provider::Claude => {
+                r#"[
+                    "button[aria-label=\"Stop response\"]",
+                    "button[aria-label*=\"Stop\"]",
+                    "button[aria-label*=\"停止\"]"
+                ]"#
+            }
         }
     }
 }
@@ -280,6 +328,7 @@ impl fmt::Display for Provider {
         match self {
             Provider::ChatGpt => write!(f, "chatgpt"),
             Provider::Gemini => write!(f, "gemini"),
+            Provider::Claude => write!(f, "claude"),
         }
     }
 }
@@ -324,7 +373,7 @@ fn parse_chatgpt_agent_prompt(prompt: &str) -> Option<ChatGptAgentPrompt<'_>> {
 #[command(name = "ask-bridge")]
 #[command(version = "0.2.1")]
 #[command(disable_version_flag = true)]
-#[command(about = "AI browser CLI - Ask ChatGPT or Gemini from your Terminal with your subscription", long_about = None)]
+#[command(about = "AI browser CLI - Ask ChatGPT, Gemini or Claude from your Terminal with your subscription", long_about = None)]
 struct Cli {
     /// The prompt to send to the selected provider.
     /// If standard input is piped and this value is present, they are combined as:
@@ -376,7 +425,8 @@ struct Cli {
     /// Switch the provider model before sending the prompt.
     /// ChatGPT examples: "GPT-5.5", "GPT-5.4", "GPT-5.3", "o3", or thinking levels such as
     /// "即時", "中等", "高", "超高", "專業", "智慧". Gemini examples: "3.5 Flash",
-    /// "3.1 Flash-Lite", or "3.1 Pro". Matching is case- and punctuation-insensitive.
+    /// "3.1 Flash-Lite", or "3.1 Pro". Claude examples: "Sonnet", "Opus", "Haiku".
+    /// Matching is case- and punctuation-insensitive.
     #[arg(long = "model", value_name = "MODEL")]
     model: Option<String>,
 
@@ -540,7 +590,9 @@ fn run_config_command(cli_provider: Option<Provider>) -> Result<(), String> {
                     config_path.to_string_lossy()
                 );
             }
-            println!("Set default provider with: ask-bridge config --provider <chatgpt|gemini>");
+            println!(
+                "Set default provider with: ask-bridge config --provider <chatgpt|gemini|claude>"
+            );
             println!("This is a one-time override example: ask-bridge --provider gemini <prompt>");
             Ok(())
         }
@@ -1480,6 +1532,14 @@ mod tests {
             parse_configured_provider(r#"{"provider":"chat-gpt"}"#).unwrap(),
             Some(Provider::ChatGpt)
         );
+        assert_eq!(
+            parse_configured_provider(r#"{"provider":"claude"}"#).unwrap(),
+            Some(Provider::Claude)
+        );
+        assert_eq!(
+            parse_configured_provider(r#"{"provider":"claude-ai"}"#).unwrap(),
+            Some(Provider::Claude)
+        );
         assert_eq!(parse_configured_provider(r#"{}"#).unwrap(), None);
     }
 
@@ -1514,7 +1574,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_provider_in_config_json() {
-        let err = parse_configured_provider(r#"{"provider":"claude"}"#).unwrap_err();
+        let err = parse_configured_provider(r#"{"provider":"copilot"}"#).unwrap_err();
         assert!(err.contains("Invalid provider"));
     }
 
@@ -1554,7 +1614,13 @@ mod tests {
 
     #[test]
     fn rejects_unknown_provider() {
-        assert!(Cli::try_parse_from(["ask-bridge", "--provider", "claude", "hello"]).is_err());
+        assert!(Cli::try_parse_from(["ask-bridge", "--provider", "copilot", "hello"]).is_err());
+    }
+
+    #[test]
+    fn parses_claude_provider_argument() {
+        let cli = Cli::try_parse_from(["ask-bridge", "--provider", "claude", "hello"]).unwrap();
+        assert_eq!(cli.provider, Some(Provider::Claude));
     }
 
     #[test]
@@ -1566,6 +1632,10 @@ mod tests {
         assert_eq!(
             Provider::from_url("https://gemini.google.com/app/abc"),
             Some(Provider::Gemini)
+        );
+        assert_eq!(
+            Provider::from_url("https://claude.ai/chat/abc"),
+            Some(Provider::Claude)
         );
         assert_eq!(Provider::from_url("https://example.com"), None);
     }
@@ -1650,6 +1720,22 @@ mod tests {
         ])
         .unwrap();
         assert!(validate_provider_feature_support(Provider::Gemini, &cli).is_err());
+    }
+
+    #[test]
+    fn allows_claude_image_and_file_attachments() {
+        let cli = Cli::try_parse_from([
+            "ask-bridge",
+            "--provider",
+            "claude",
+            "--image",
+            "token.png",
+            "--file",
+            "token.txt",
+            "read",
+        ])
+        .unwrap();
+        assert!(validate_provider_feature_support(Provider::Claude, &cli).is_ok());
     }
 
     #[test]
@@ -1941,7 +2027,7 @@ fn click_latest_copy_button(config_path: &str, provider: Provider) -> Result<(),
                     if (el.closest('pre, code, [class*="code"], [data-testid*="code"]')) return -1;
                     if (/copy-turn-action-button/i.test(label)) return 100;
                     if (/response|回應|回答|reply/i.test(label)) return 90;
-                    if (el.closest('model-response, response-container, [data-message-author-role="assistant"], .agent-turn')) return 50;
+                    if (el.closest('model-response, response-container, [data-message-author-role="assistant"], .agent-turn, [data-is-streaming], .font-claude-message')) return 50;
                     return 10;
                 };
                 const messages = Array.from(document.querySelectorAll(__RESPONSE_SELECTOR__));
@@ -2701,6 +2787,8 @@ fn upload_attachments_via_file_chooser(
                     .or_else(|| find_snapshot_uid(&snapshot, &["upload"], &["drive"]))
             }
             Provider::ChatGpt => find_snapshot_uid(&snapshot, &["attach"], &["settings", "menu"]),
+            Provider::Claude => find_snapshot_uid(&snapshot, &["attach"], &["settings", "menu"])
+                .or_else(|| find_snapshot_uid(&snapshot, &["upload"], &["drive"])),
         }
         .ok_or_else(|| {
             format!(
@@ -2724,6 +2812,10 @@ fn upload_attachments_via_file_chooser(
             Provider::Gemini => find_snapshot_uid(&snapshot, &["上傳檔案"], &["雲端", "drive"])
                 .or_else(|| find_snapshot_uid(&snapshot, &["upload", "file"], &["drive"])),
             Provider::ChatGpt => find_snapshot_uid(&snapshot, &["file"], &["drive", "connect"]),
+            Provider::Claude => {
+                find_snapshot_uid(&snapshot, &["upload", "file"], &["drive", "connect"])
+                    .or_else(|| find_snapshot_uid(&snapshot, &["file"], &["drive", "connect"]))
+            }
         }
         .unwrap_or_else(|| menu_uid.clone());
 
@@ -3190,6 +3282,68 @@ fn switch_model(
                         chosen.click();
                         await sleep(500);
                         window.__switch_model_status = 'success:' + (chosen.innerText || chosen.textContent || '').trim();
+                    } catch (e) {
+                        window.__switch_model_status = 'error: ' + e.message;
+                    }
+                })();
+                return true;
+            }"#;
+            template.replace("__TARGET_MODEL__", &target_json)
+        }
+        Provider::Claude => {
+            let template = r#"() => {
+                window.__switch_model_status = 'pending';
+                (async () => {
+                    try {
+                        const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+                        const norm = (s) => (s || '').toLowerCase().replace(/[\s.\-_]/g, '');
+                        const labelOf = (el) => ((el.innerText || el.textContent || '').split('\n')[0] || '').trim();
+                        const target = norm(__TARGET_MODEL__);
+                        if (!target) { window.__switch_model_status = 'error: empty target'; return; }
+                        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
+                        await sleep(300);
+                        let trigger = document.querySelector('[data-testid="model-selector-dropdown"]');
+                        if (!trigger) {
+                            trigger = Array.from(document.querySelectorAll('button')).find((button) => {
+                                const popup = button.getAttribute('aria-haspopup');
+                                if (popup !== 'menu' && popup !== 'listbox') return false;
+                                const label = [button.getAttribute('aria-label'), button.textContent].filter(Boolean).join(' ');
+                                return /model|claude|opus|sonnet|haiku|fable/i.test(label);
+                            });
+                        }
+                        if (!trigger) { window.__switch_model_status = 'error: Claude model selector not found'; return; }
+                        trigger.click();
+                        await sleep(800);
+                        const visited = new Set();
+                        let clicked = false;
+                        let chosen = '';
+                        for (let depth = 0; depth < 4 && !clicked; depth++) {
+                            const items = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"], [role="menuitemradio"]'));
+                            const leaves = items.filter((it) => it.getAttribute('aria-haspopup') !== 'menu');
+                            let match = leaves.find((it) => norm(labelOf(it)) === target);
+                            if (!match) match = leaves.find((it) => norm(labelOf(it)).startsWith(target));
+                            if (match) {
+                                match.click();
+                                clicked = true;
+                                chosen = labelOf(match);
+                                break;
+                            }
+                            const trigs = items.filter((it) => it.getAttribute('aria-haspopup') === 'menu');
+                            const trig = trigs.find((it) => !visited.has(norm(it.innerText)));
+                            if (!trig) break;
+                            visited.add(norm(trig.innerText));
+                            trig.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+                            trig.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+                            trig.click();
+                            await sleep(700);
+                        }
+                        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
+                        if (!clicked) {
+                            window.__switch_model_status = 'error: model not found in menu';
+                            return;
+                        }
+                        await sleep(400);
+                        window.__switch_model_status = 'success:' + chosen;
                     } catch (e) {
                         window.__switch_model_status = 'error: ' + e.message;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,11 +208,34 @@ impl Provider {
             }
             Provider::Claude => {
                 r#"() => {
+                    const isVisible = (el) => {
+                        if (!el) return false;
+                        const style = window.getComputedStyle(el);
+                        const rect = el.getBoundingClientRect();
+                        return style.display !== 'none' &&
+                            style.visibility !== 'hidden' &&
+                            style.opacity !== '0' &&
+                            rect.width > 0 &&
+                            rect.height > 0;
+                    };
                     const composer = document.querySelector('div[contenteditable="true"][data-testid="chat-input"]') ||
                         document.querySelector('div[contenteditable="true"].ProseMirror');
-                    const loginIndicator = document.querySelector('[data-testid="login-with-google"]') !== null ||
-                        window.location.pathname.startsWith('/login');
-                    return Boolean(composer) && !loginIndicator;
+                    const account = document.querySelector('[data-testid="user-menu-button"]') ||
+                        document.querySelector('button[aria-label*="User menu"]') ||
+                        document.querySelector('button[aria-label*="Account"]');
+                    const signIn = document.querySelector('[data-testid="login-with-google"]') ||
+                        Array.from(document.querySelectorAll('a, button'))
+                            .find((el) => isVisible(el) && /^(log in|login|sign in|sign up|登入|註冊)$/i.test([
+                                    el.getAttribute('aria-label'),
+                                    el.textContent
+                                ].filter(Boolean).join(' ').trim()));
+                    const authPath = /^\/(login|signup|magic-link)(\/|$)/i.test(window.location.pathname);
+                    return {
+                        account: isVisible(account),
+                        auth_control: Boolean(signIn),
+                        auth_path: authPath,
+                        composer: Boolean(composer)
+                    };
                 }"#
             }
         }


### PR DESCRIPTION
## 摘要

新增 **Claude（claude.ai）** 作為第三個 provider，與 ChatGPT、Gemini 採完全相同的瀏覽器自動化架構：以 `--provider claude` 透過 Chrome 自動開啟 claude.ai、送出 prompt、等待生成並將回覆取回終端機，使用網站訂閱額度而非 API。

## 主要變更

- **`src/main.rs`**
  - `Provider` enum 新增 `Claude` variant，補齊 URL、登入偵測、composer、送出/停止按鈕與回覆容器等全部 selector 分支（config 值支援 `claude` / `claude-ai` / `claude_ai` / `claudeai` 從寬解析）
  - `switch_model` 支援 claude.ai 模型選單（`--model Sonnet` / `Opus` / `Haiku`，不分大小寫與標點，支援子選單走訪）
  - 附件上傳開放 Claude 走既有 DataTransfer 路徑：`--image` 與 `--file` 皆支援
  - CLI `about`、`--model` 說明與 `config` 提示改為 `chatgpt|gemini|claude`
  - 測試：無效 provider 案例改用 `copilot`，新增 Claude 解析、URL 對應與附件功能測試（`cargo test` 20 項全數通過）
- **文件**：README（中/英）、`skills/ask-bridge/SKILL.md`、`docs/quick-start.md`、`AGENTS.md`、`package.json` 同步納入 Claude 說明與範例

## Selector 校準備註

claude.ai 現行 DOM 已實測校準：composer 以 `data-testid="chat-input"` 為第一優先；回覆容器採 `.font-claude-response`（每則回覆恆存在）。特別注意 **`data-is-streaming` 屬性僅掛在最後一則回覆容器**，若以其計數訊息數，多輪對話中數量不會遞增而導致等待逾時，故不採用。

## 驗證

Windows 11 + claude.ai（英文介面）實測通過：

- [x] `ask-bridge --provider claude login`（未登入偵測與登入流程）
- [x] 基本問答與分頁重用、Thread Link 輸出
- [x] `--new` 開啟全新對話（產生新 thread UUID）
- [x] `--file` 文件附件（Claude 正確讀取內容作答）
- [x] `--image` 圖片附件（Claude 正確描述圖片）
- [x] `--model Haiku` / `--model Sonnet` 模型切換
- [x] `-o` Markdown 檔案輸出
- [x] `cargo test`（20 passed）、`cargo fmt --all -- --check`

<img width="938" height="719" alt="image" src="https://github.com/user-attachments/assets/60aa4c5d-33af-4a81-b7c1-1f4b4a25ed6b" />

<img width="793" height="855" alt="image" src="https://github.com/user-attachments/assets/f18980e1-fe53-4bbf-a8bc-39b1343de9f2" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
