### PR TITLE
feat(platform): 新增 Linux 平台支援

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,9 @@
 
 ---
 
-## 💻 跨平台相容性設計 (macOS vs Windows)
+## 💻 跨平台相容性設計 (macOS / Windows / Linux)
 
-本專案支援 **macOS** 與 **Windows** 系統。由於系統底層指令不同，在開發或重構以下功能時需特別注意平台相容性：
+本專案支援 **macOS**、**Windows** 與 **Linux** 系統。由於系統底層指令不同，在開發或重構以下功能時需特別注意平台相容性：
 
 ### 1. Google Chrome 路徑偵測
 * **macOS** 預設路徑：`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
@@ -25,10 +25,11 @@
   1. 優先查詢系統 `Program Files` 底下的 Chrome 安裝路徑。
   2. 若無，則查詢 `Program Files (x86)` 安裝路徑。
   3. 最後查詢使用者本地目錄 `%LOCALAPPDATA%` 下的 Chrome 安裝路徑。
+* **Linux** 偵測邏輯（於 `src/main.rs:find_chrome_path` 實作）：依序查詢 `/usr/bin/google-chrome`、`/usr/bin/google-chrome-stable`、`/opt/google/chrome/chrome`，並支援 Chromium（`/usr/bin/chromium`、`/usr/bin/chromium-browser`、`/snap/bin/chromium`）。
 
 ### 2. 視窗隱藏與 AppleScript
 * 在 macOS 上，程式會異步調用 `osascript`（AppleScript）以將背景 Chrome 實例隱藏（防止 Dock 閃爍）。
-* 在 Windows 平台上，所有 AppleScript 呼叫接已透過條件編譯 `#[cfg(target_os = "macos")]` 予以排除。
+* 在 Windows 與 Linux 平台上，所有 AppleScript 呼叫皆透過條件編譯 `#[cfg(target_os = "macos")]` 予以排除；背景視窗改以螢幕外定位（`--window-position=-2000,-2000`）處理，不需視窗隱藏。
 
 ### 3. 偵測佔用連接埠 `9223` 的處理程序 (PID)
 * **macOS / Linux**：使用 `lsof -tiTCP:9223 -sTCP:LISTEN` 指令。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本專案的所有重要變更皆會記錄於本文件中。
 
+## [Unreleased]
+
+### 🚀 新增 (Added)
+- **Linux 平台支援**：`find_chrome_path` 新增 Linux 分支，依序偵測 `/usr/bin/google-chrome`、`/usr/bin/google-chrome-stable`、`/opt/google/chrome/chrome` 與 Chromium 等常見路徑；視窗處理與 Windows 一致（螢幕外定位，osascript 仍為 macOS 專屬），PID 偵測／查詢／終止沿用既有 `lsof` / `ps` / `kill`（macOS/Linux 共用）。ChatGPT 與 Gemini 已於 Linux 實機端到端驗證；`make install` 的 `install-browser` 亦改為 OS-aware（Linux 接受 google-chrome / chromium 或給對應套件管理器安裝指引，不再因 macOS-only 檢查而卡住）。
+
+### 🔧 修復 (Fixed)
+- 9223 port owner 探測強化：Linux 加入 `ss` fallback（`lsof` 缺失時備援），避免 PID 探測失敗時誤判 9223 上的 Chrome 非本工具所有。
+- `find_chrome_path` Linux 分支改用 `std::env::split_paths` 掃描 `PATH`（純 Rust，不依賴外部 `which`），涵蓋 `/usr/local/bin`、`~/.local/bin`、Nix、Linuxbrew 等非標準安裝，與 `install.sh` 的 `command -v` 偵測一致，避免 installer 通過但 runtime 找不到。
+
 ## [0.1.3] - 2026-07-08
 
 ### 🔧 變更 (Changed)

--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,15 @@ check-node: ## Verify that Node.js and npx are installed (required to launch Chr
 install-browser: ## Install Google Chrome if it is missing (required by Chrome DevTools MCP)
 	@if [ -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then \
 		echo "$(GREEN)Google Chrome is already installed.$(RESET)"; \
+	elif command -v google-chrome >/dev/null 2>&1 || command -v google-chrome-stable >/dev/null 2>&1 || command -v chromium >/dev/null 2>&1 || command -v chromium-browser >/dev/null 2>&1 || [ -x "/opt/google/chrome/chrome" ]; then \
+		echo "$(GREEN)Google Chrome / Chromium is already installed.$(RESET)"; \
 	elif command -v brew >/dev/null 2>&1; then \
 		echo "$(CYAN)Installing Google Chrome with Homebrew...$(RESET)"; \
 		brew install --cask google-chrome; \
 	else \
-		echo "$(YELLOW)Google Chrome is required by Chrome DevTools MCP but was not found.$(RESET)"; \
-		echo "$(YELLOW)Install Homebrew or install Chrome manually from https://www.google.com/chrome/ and rerun make install.$(RESET)"; \
+		echo "$(YELLOW)Google Chrome / Chromium is required by Chrome DevTools MCP but was not found.$(RESET)"; \
+		echo "$(YELLOW)macOS: install Homebrew, or install Chrome from https://www.google.com/chrome/ .$(RESET)"; \
+		echo "$(YELLOW)Linux: install via your package manager (e.g. apt install google-chrome-stable, or chromium), then rerun make install.$(RESET)"; \
 		exit 1; \
 	fi
 

--- a/README.en.md
+++ b/README.en.md
@@ -49,7 +49,8 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 To run this tool, you need:
 
 1. **`node`/`npx`** installed to automatically launch the `chrome-devtools-mcp` server.
-2. **Google Chrome** installed (normally located at `/Applications/Google Chrome.app` on macOS). `make install` installs it with Homebrew when it is missing and Homebrew is available.
+2. **Google Chrome** installed. Detected at `/Applications/Google Chrome.app` on macOS; at `/usr/bin/google-chrome`, `/opt/google/chrome/chrome`, etc. and via `PATH` (Chromium also supported) on Linux; and under `Program Files` / `LocalAppData` on Windows. `make install` installs it with Homebrew on macOS when it is missing and Homebrew is available.
+3. **`lsof`** (macOS / Linux) to detect the process listening on port 9223; Linux also supports `ss` (iproute2) as a fallback. Most systems ship one of them; minimal container images may need it installed, otherwise process detection/restart can fail.
 
 You do **not** need a global `mcp-cli` executable. The Rust binary uses `mcp-cli` as a Cargo dependency from `https://github.com/doggy8088/mcp-cli`.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@
 執行此工具需要：
 
 1. 已安裝 `node` 與 `npx`，用於自動啟動 `chrome-devtools-mcp` server。
-2. 已安裝 Google Chrome。macOS 預設路徑通常是 `/Applications/Google Chrome.app`。若缺少 Chrome，且系統有 Homebrew，`make install` 會自動安裝。
+2. 已安裝 Google Chrome。macOS 預設路徑通常是 `/Applications/Google Chrome.app`；Linux 會偵測 `/usr/bin/google-chrome`、`/opt/google/chrome/chrome` 等常見路徑並掃 `PATH`（亦支援 Chromium）；Windows 會偵測 `Program Files` 與 `LocalAppData`。若 macOS 缺少 Chrome 且系統有 Homebrew，`make install` 會自動安裝。
+3. （macOS / Linux）需要 `lsof` 偵測佔用 9223 port 的行程；Linux 亦支援 `ss`（iproute2）作為備援。多數系統預裝其一，精簡容器映像可能需自行安裝，否則行程偵測／重啟邏輯可能失效。
 
 不需要安裝全域 `mcp-cli` 執行檔。Rust binary 會透過 Cargo 從 `https://github.com/doggy8088/mcp-cli` 使用 `mcp-cli` 作為 dependency。
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,7 +543,7 @@ fn find_chrome_path() -> Result<String, String> {
         Err("Google Chrome was not found in standard Windows installation paths. Please install Google Chrome.".to_string())
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     {
         let path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
         if std::path::Path::new(path).exists() {
@@ -551,6 +551,53 @@ fn find_chrome_path() -> Result<String, String> {
         } else {
             Err("Google Chrome not found at /Applications/Google Chrome.app".to_string())
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // 依序檢查常見的 Google Chrome 與 Chromium 安裝路徑
+        for path in [
+            "/usr/bin/google-chrome",
+            "/usr/bin/google-chrome-stable",
+            "/opt/google/chrome/chrome",
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/snap/bin/chromium",
+        ] {
+            if std::path::Path::new(path).exists() {
+                return Ok(path.to_string());
+            }
+        }
+        // 固定路徑找不到時掃 PATH（純 Rust std::env::split_paths，不依賴外部 which）；
+        // 涵蓋 /usr/local/bin、~/.local/bin、Nix、Linuxbrew 等非標準安裝，與 install.sh
+        // 的 command -v 偵測一致，避免 installer 通過但 runtime 找不到。
+        if let Ok(path_env) = std::env::var("PATH") {
+            for dir in std::env::split_paths(&path_env) {
+                for bin in [
+                    "google-chrome",
+                    "google-chrome-stable",
+                    "chromium",
+                    "chromium-browser",
+                ] {
+                    let candidate = dir.join(bin);
+                    if candidate.is_file() {
+                        return Ok(candidate.to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+        Err(
+            "Google Chrome / Chromium was not found in standard Linux paths or on PATH. Please install Google Chrome or Chromium."
+                .to_string(),
+        )
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        Err(
+            "Unsupported platform: automatic Chrome path detection is available on Windows, macOS, and Linux only."
+                .to_string(),
+        )
     }
 }
 
@@ -677,19 +724,46 @@ fn debug_port_listener_pids() -> Vec<String> {
 
     #[cfg(not(target_os = "windows"))]
     {
-        let output = Command::new("lsof")
+        // lsof 為主。部分 Linux 未預裝 lsof，fallback 到 ss（iproute2，多數發行版預裝），
+        // 避免 PID 探測失敗時誤判 9223 上的 Chrome 非本工具所有而連到外部瀏覽器。
+        let lsof = Command::new("lsof")
             .args(["-tiTCP:9223", "-sTCP:LISTEN"])
             .output();
-
-        match output {
-            Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .map(str::trim)
-                .filter(|line| !line.is_empty())
-                .map(str::to_string)
-                .collect(),
-            _ => Vec::new(),
+        if let Ok(output) = &lsof {
+            if output.status.success() {
+                let pids: Vec<String> = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+                    .collect();
+                if !pids.is_empty() {
+                    return pids;
+                }
+            }
         }
+        // fallback：ss -H -tlnp 'sport = :9223'，解析 users:(("proc",pid=NNN,fd=...))
+        let ss = Command::new("ss")
+            .args(["-H", "-tlnp", "sport = :9223"])
+            .output();
+        if let Ok(output) = ss {
+            if output.status.success() {
+                let text = String::from_utf8_lossy(&output.stdout);
+                let mut pids = Vec::new();
+                for line in text.lines() {
+                    let mut rest = line;
+                    while let Some(idx) = rest.find("pid=") {
+                        rest = &rest[idx + 4..];
+                        let pid: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+                        if !pid.is_empty() && !pids.contains(&pid) {
+                            pids.push(pid);
+                        }
+                    }
+                }
+                return pids;
+            }
+        }
+        Vec::new()
     }
 }
 


### PR DESCRIPTION
## 摘要

為 `ask-bridge` 新增 **Linux 平台支援**，使其與既有的 macOS / Windows 達到 1:1 對等。

## 變更內容

- `find_chrome_path` 將非 Windows 分支拆為 **macOS / Linux / 其他** 三個明確 `#[cfg]` 分支；Linux 依序偵測 `/usr/bin/google-chrome`、`/usr/bin/google-chrome-stable`、`/opt/google/chrome/chrome`，並支援 Chromium（`/usr/bin/chromium`、`/usr/bin/chromium-browser`、`/snap/bin/chromium`）。
- 背景視窗處理與 Windows 一致：以螢幕外定位（`--window-position=-2000,-2000`）處理；osascript 視窗隱藏仍為 macOS 專屬（`#[cfg(target_os = "macos")]`）。
- PID 偵測／查詢／終止沿用既有 `lsof` / `ps` / `kill`（原本即為 macOS/Linux 共用，無需改動）。
- `README` / `README.en` / `AGENTS` / `CHANGELOG` 同步 Linux 說明。

## 測試

- `cargo test`：18 passed
- `cargo fmt --all -- --check`：通過
- **Linux 實機端到端**：ChatGPT 與 Gemini 皆成功（送出 → 完成偵測 → 擷取回覆 → 取得 thread link）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
