### PR TITLE
feat(provider): 新增 Claude (claude.ai) 網頁版 provider 支援

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 本專案的所有重要變更皆會記錄於本文件中。
 
+## [Unreleased]
+
+### 🚀 新增 (Added)
+- **Claude 網頁版 provider 支援**：新增 `--provider claude`，可透過 claude.ai 網頁送出文字 prompt 並取回回覆。登入偵測、composer、送出／停止按鈕與回覆容器 selector 均採語意屬性（`data-testid` / `aria-label`）並經實站校正。第一版僅支援純文字 prompt，尚不支援 `--image` / `--file` 附件與 `--model` 模型切換（由 `validate_provider_feature_support` 明確擋下並回報清楚訊息）。
+
+### 🔧 修復 (Fixed)
+- 回應 codex 對抗審查／PR review comments：(1) Claude `ready_check` 加入登入頁指標（`/login` 連結或 Log in／Sign in／登入 文字），避免登出／新 profile 首次 `login` 卡到 timeout；(2) Claude assistant／回覆 selector 改用 `div[data-is-streaming="false"]`（僅完成的訊息），避免串流中被誤判為完成而截斷（實測 claude 完成後容器為 `data-is-streaming="false"`）。
+
+---
+
 ## [0.1.4] - 2026-07-09
 
 ### 🔧 修復 (Fixed)

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # Ask Bridge 🦀
 
-`ask-bridge` is a powerful, lightweight command-line tool written in **Rust** that automates ChatGPT or Gemini directly in your real Chrome browser. It uses the **Model Context Protocol (MCP)** and **Chrome DevTools Protocol (CDP)** via the embedded `doggy8088/mcp-cli` Rust library dependency and `chrome-devtools-mcp` to control Chrome, input prompts, click submit, and print the response back to your terminal. ChatGPT is the default when no global provider is configured; use `--provider gemini` or the global config file to switch to Gemini.
+`ask-bridge` is a powerful, lightweight command-line tool written in **Rust** that automates ChatGPT, Gemini, or Claude directly in your real Chrome browser. It uses the **Model Context Protocol (MCP)** and **Chrome DevTools Protocol (CDP)** via the embedded `doggy8088/mcp-cli` Rust library dependency and `chrome-devtools-mcp` to control Chrome, input prompts, click submit, and print the response back to your terminal. ChatGPT is the default when no global provider is configured; use `--provider gemini`, `--provider claude`, or the global config file to switch to Gemini or Claude.
 
 ## Design Intent
 
@@ -29,7 +29,7 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 ## 🌟 Key Features
 
 - **🦀 100% Rust Core**: Extremely fast, lightweight, and compile-once, run-anywhere binary.
-- **Multi-provider support**: Choose ChatGPT or Gemini with `--provider chatgpt|gemini`.
+- **Multi-provider support**: Choose ChatGPT, Gemini, or Claude with `--provider chatgpt|gemini|claude`.
 - **Global provider config**: Set the default provider in `~/.config/ask-bridge/config.json`; CLI `--provider` overrides the config file.
 - **🌐 Real Browser Automation**: Directly interacts with Chrome on port `9223` (isolated debug profile).
 - **🔒 Persistent Login**: Uses a dedicated local profile directory (`~/.config/ask-bridge/chrome-profile`) so you never lose your login state.
@@ -37,8 +37,8 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 - **🌀 TUI Thinking Animation**: Displays a rotating spinner while waiting for the provider to reply, then clears it once output starts.
 - **🧠 Intelligent Tab Management**: Reuses existing provider tabs if open, focuses them, or opens new ones, avoiding tab clutter.
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask-bridge "summarize this"`).
-- **📎 Image & File Attachments**: Attach local images to ChatGPT with `--image`, or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`.
-- **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4` or Gemini `3.5 Flash`.
+- **📎 Image & File Attachments**: Attach local images to ChatGPT with `--image`, or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`; Claude currently supports text-only prompts and rejects both `--image` and `--file`.
+- **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4` or Gemini `3.5 Flash`; Claude does not support model switching.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
 - **Version Info**: Use `-v` or `--version` to print the current version number.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ask Bridge 🦀
 
-`ask-bridge` 是以 Rust 撰寫的輕量命令列工具，可透過真實 Chrome 瀏覽器自動操作 ChatGPT 與 Gemini。它使用 Model Context Protocol MCP 與 Chrome DevTools Protocol CDP，並透過內建的 `doggy8088/mcp-cli` Rust library dependency 搭配 `chrome-devtools-mcp` 控制 Chrome、輸入 prompt、送出訊息，並將回覆輸出到終端機。未設定全域 provider 時預設使用 ChatGPT，可用 `--provider gemini` 或全域設定檔切換到 Gemini。
+`ask-bridge` 是以 Rust 撰寫的輕量命令列工具，可透過真實 Chrome 瀏覽器自動操作 ChatGPT、Gemini 與 Claude。它使用 Model Context Protocol MCP 與 Chrome DevTools Protocol CDP，並透過內建的 `doggy8088/mcp-cli` Rust library dependency 搭配 `chrome-devtools-mcp` 控制 Chrome、輸入 prompt、送出訊息，並將回覆輸出到終端機。未設定全域 provider 時預設使用 ChatGPT，可用 `--provider gemini`、`--provider claude` 或全域設定檔切換到 Gemini 或 Claude。
 
 ## 設計意圖
 
@@ -28,7 +28,7 @@
 ## 主要功能
 
 - **100% Rust 核心**：快速、輕量，編譯後即可執行。
-- **多 provider 支援**：使用 `--provider chatgpt|gemini` 選擇 ChatGPT 或 Gemini。
+- **多 provider 支援**：使用 `--provider chatgpt|gemini|claude` 選擇 ChatGPT、Gemini 或 Claude。
 - **全域 provider 設定**：可在 `~/.config/ask-bridge/config.json` 指定預設 provider，CLI 的 `--provider` 會覆蓋設定檔。
 - **真實瀏覽器自動化**：直接控制監聽 `9223` port 的 Chrome debug profile。
 - **持久登入狀態**：使用專屬本機 profile 目錄 `~/.config/ask-bridge/chrome-profile`，避免重複登入。
@@ -36,8 +36,8 @@
 - **思考動畫**：等待 provider 回覆時，在終端機顯示旋轉 spinner，開始輸出內容後自動清除。
 - **智慧分頁管理**：可重用既有 provider 分頁、聚焦分頁，或開啟新分頁，避免分頁過度增加。
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask-bridge "summarize this"`。
-- **圖片與文件上傳**：可透過 `--image` 附上 ChatGPT 圖片，或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入。
-- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，或 Gemini 的 `3.5 Flash`、`3.1 Pro`）。
+- **圖片與文件上傳**：可透過 `--image` 附上 ChatGPT 圖片，或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入；Claude 目前僅支援純文字 prompt，不支援 `--image` 與 `--file`。
+- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，或 Gemini 的 `3.5 Flash`、`3.1 Pro`）；Claude 目前不支援模型切換。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
 - **版本資訊**：使用 `-v` 或 `--version` 顯示目前版本號。
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ enum Provider {
     ChatGpt,
     #[value(name = "gemini")]
     Gemini,
+    #[value(name = "claude")]
+    Claude,
 }
 
 impl Provider {
@@ -24,6 +26,7 @@ impl Provider {
         match value.trim().to_ascii_lowercase().as_str() {
             "chatgpt" | "chat-gpt" | "chat_gpt" => Some(Provider::ChatGpt),
             "gemini" => Some(Provider::Gemini),
+            "claude" | "claude-ai" | "claude_ai" => Some(Provider::Claude),
             _ => None,
         }
     }
@@ -32,6 +35,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "ChatGPT",
             Provider::Gemini => "Gemini",
+            Provider::Claude => "Claude",
         }
     }
 
@@ -39,6 +43,7 @@ impl Provider {
         match self {
             Provider::ChatGpt => "https://chatgpt.com/",
             Provider::Gemini => "https://gemini.google.com/app",
+            Provider::Claude => "https://claude.ai/new",
         }
     }
 
@@ -46,11 +51,12 @@ impl Provider {
         match self {
             Provider::ChatGpt => url.contains("chatgpt.com"),
             Provider::Gemini => url.contains("gemini.google.com"),
+            Provider::Claude => url.contains("claude.ai"),
         }
     }
 
     fn from_url(url: &str) -> Option<Self> {
-        [Provider::ChatGpt, Provider::Gemini]
+        [Provider::ChatGpt, Provider::Gemini, Provider::Claude]
             .into_iter()
             .find(|provider| provider.owns_url(url))
     }
@@ -65,6 +71,13 @@ impl Provider {
                            document.querySelector('.ql-editor[contenteditable="true"]') !== null ||
                            document.querySelector('a[href*="accounts.google.com"]') !== null ||
                            /Sign in|登入/.test(document.body.innerText || '');
+                }"#
+            }
+            Provider::Claude => {
+                r#"() => {
+                    return document.querySelector('[data-testid="chat-input"]') !== null ||
+                           document.querySelector('a[href*="/login"]') !== null ||
+                           /Log in|Sign in|登入/.test(document.body.innerText || '');
                 }"#
             }
         }
@@ -136,6 +149,9 @@ impl Provider {
                     return Boolean(composer) && (Boolean(account) || !signIn);
                 }"#
             }
+            Provider::Claude => {
+                r#"() => document.querySelector('[data-testid="user-menu-button"]') !== null"#
+            }
         }
     }
 
@@ -143,6 +159,10 @@ impl Provider {
         match self {
             Provider::ChatGpt => "[data-message-author-role=\"assistant\"], .agent-turn",
             Provider::Gemini => "model-response",
+            // data-is-streaming 為 Claude assistant 回覆專屬串流標記（user turn 用
+            // [data-testid="user-message"]，無此屬性）；"false" = 已完成的 assistant 訊息，
+            // 據此鎖定「新完成的 assistant turn」，避免串流中（無此屬性或為 "true"）誤判完成。
+            Provider::Claude => "div[data-is-streaming=\"false\"]",
         }
     }
 
@@ -152,6 +172,10 @@ impl Provider {
                 "[data-message-author-role=\"assistant\"], .agent-turn, model-response, .model-response, [data-test-id*=\"response\"], [data-testid*=\"response\"]"
             }
             Provider::Gemini => "model-response",
+            // data-is-streaming 為 Claude assistant 回覆專屬串流標記（user turn 用
+            // [data-testid="user-message"]，無此屬性）；"false" = 已完成的 assistant 訊息，
+            // 據此鎖定「新完成的 assistant turn」，避免串流中（無此屬性或為 "true"）誤判完成。
+            Provider::Claude => "div[data-is-streaming=\"false\"]",
         }
     }
 
@@ -161,6 +185,7 @@ impl Provider {
             Provider::Gemini => {
                 "message-content, .markdown, structured-content-container.model-response-text"
             }
+            Provider::Claude => "",
         }
     }
 
@@ -172,6 +197,13 @@ impl Provider {
                     "div[role=\"textbox\"][aria-label*=\"Gemini\"]",
                     "rich-textarea [contenteditable=\"true\"]",
                     ".ql-editor[contenteditable=\"true\"]"
+                ]"#
+            }
+            Provider::Claude => {
+                r#"[
+                    "[data-testid=\"chat-input\"]",
+                    "div[contenteditable=\"true\"].ProseMirror",
+                    "div[contenteditable=\"true\"]"
                 ]"#
             }
         }
@@ -197,6 +229,13 @@ impl Provider {
                     "button[aria-label*=\"提交\"]"
                 ]"#
             }
+            Provider::Claude => {
+                r#"[
+                    "button[aria-label=\"Send message\"]",
+                    "button[aria-label*=\"Send\"]",
+                    "button[aria-label*=\"傳送\"]"
+                ]"#
+            }
         }
     }
 
@@ -216,6 +255,13 @@ impl Provider {
                     "button[aria-label*=\"停止\"]"
                 ]"#
             }
+            Provider::Claude => {
+                r#"[
+                    "button[aria-label=\"Stop response\"]",
+                    "button[aria-label*=\"Stop\"]",
+                    "button[aria-label*=\"停止\"]"
+                ]"#
+            }
         }
     }
 }
@@ -225,6 +271,7 @@ impl fmt::Display for Provider {
         match self {
             Provider::ChatGpt => write!(f, "chatgpt"),
             Provider::Gemini => write!(f, "gemini"),
+            Provider::Claude => write!(f, "claude"),
         }
     }
 }
@@ -1187,6 +1234,20 @@ fn validate_provider_feature_support(provider: Provider, cli: &Cli) -> Result<()
         );
     }
 
+    if provider == Provider::Claude && (!cli.images.is_empty() || !cli.files.is_empty()) {
+        return Err(
+            "Claude attachments are not supported yet. The Claude provider currently supports text prompts only."
+                .to_string(),
+        );
+    }
+
+    if provider == Provider::Claude && cli.model.is_some() {
+        return Err(
+            "Claude model switching is not supported yet. Remove --model to use the current Claude model."
+                .to_string(),
+        );
+    }
+
     Ok(())
 }
 
@@ -1252,6 +1313,10 @@ mod tests {
             parse_configured_provider(r#"{"provider":"chat-gpt"}"#).unwrap(),
             Some(Provider::ChatGpt)
         );
+        assert_eq!(
+            parse_configured_provider(r#"{"provider":"claude"}"#).unwrap(),
+            Some(Provider::Claude)
+        );
         assert_eq!(parse_configured_provider(r#"{}"#).unwrap(), None);
     }
 
@@ -1286,7 +1351,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_provider_in_config_json() {
-        let err = parse_configured_provider(r#"{"provider":"claude"}"#).unwrap_err();
+        let err = parse_configured_provider(r#"{"provider":"grok"}"#).unwrap_err();
         assert!(err.contains("Invalid provider"));
     }
 
@@ -1326,7 +1391,13 @@ mod tests {
 
     #[test]
     fn rejects_unknown_provider() {
-        assert!(Cli::try_parse_from(["ask-bridge", "--provider", "claude", "hello"]).is_err());
+        assert!(Cli::try_parse_from(["ask-bridge", "--provider", "grok", "hello"]).is_err());
+    }
+
+    #[test]
+    fn accepts_claude_provider() {
+        let cli = Cli::try_parse_from(["ask-bridge", "--provider", "claude", "hello"]).unwrap();
+        assert_eq!(cli.provider, Some(Provider::Claude));
     }
 
     #[test]
@@ -1338,6 +1409,10 @@ mod tests {
         assert_eq!(
             Provider::from_url("https://gemini.google.com/app/abc"),
             Some(Provider::Gemini)
+        );
+        assert_eq!(
+            Provider::from_url("https://claude.ai/chat/abc"),
+            Some(Provider::Claude)
         );
         assert_eq!(Provider::from_url("https://example.com"), None);
     }
@@ -1505,6 +1580,40 @@ mod tests {
         let profile_path = "/Users/will/.config/ask-bridge/chrome-profile";
 
         assert!(!command_uses_profile(command, profile_path));
+    }
+
+    #[test]
+    fn rejects_claude_attachments() {
+        let cli = Cli::try_parse_from([
+            "ask-bridge",
+            "--provider",
+            "claude",
+            "--file",
+            "token.txt",
+            "read",
+        ])
+        .unwrap();
+        assert!(validate_provider_feature_support(Provider::Claude, &cli).is_err());
+    }
+
+    #[test]
+    fn rejects_claude_model_switch() {
+        let cli = Cli::try_parse_from([
+            "ask-bridge",
+            "--provider",
+            "claude",
+            "--model",
+            "opus",
+            "read",
+        ])
+        .unwrap();
+        assert!(validate_provider_feature_support(Provider::Claude, &cli).is_err());
+    }
+
+    #[test]
+    fn allows_claude_text_prompt() {
+        let cli = Cli::try_parse_from(["ask-bridge", "--provider", "claude", "read"]).unwrap();
+        assert!(validate_provider_feature_support(Provider::Claude, &cli).is_ok());
     }
 }
 
@@ -2333,6 +2442,8 @@ fn upload_attachments_via_file_chooser(
                     .or_else(|| find_snapshot_uid(&snapshot, &["upload"], &["drive"]))
             }
             Provider::ChatGpt => find_snapshot_uid(&snapshot, &["attach"], &["settings", "menu"]),
+            // 上傳由 validate_provider_feature_support 提前擋下，此分支不可達
+            Provider::Claude => None,
         }
         .ok_or_else(|| {
             format!(
@@ -2356,6 +2467,7 @@ fn upload_attachments_via_file_chooser(
             Provider::Gemini => find_snapshot_uid(&snapshot, &["上傳檔案"], &["雲端", "drive"])
                 .or_else(|| find_snapshot_uid(&snapshot, &["upload", "file"], &["drive"])),
             Provider::ChatGpt => find_snapshot_uid(&snapshot, &["file"], &["drive", "connect"]),
+            Provider::Claude => None,
         }
         .unwrap_or_else(|| menu_uid.clone());
 
@@ -2711,6 +2823,13 @@ fn switch_model(
     }
 
     let js = match provider {
+        // model 切換由 validate_provider_feature_support 提前擋下，此分支不可達
+        Provider::Claude => {
+            return Err(
+                "Claude model switching is not supported yet. Remove --model to use the current Claude model."
+                    .to_string(),
+            );
+        }
         Provider::ChatGpt => {
             // The script opens the composer pill menu, walks visible leaves and submenu
             // triggers, and clicks the first leaf whose normalized label matches.


### PR DESCRIPTION
## 摘要

新增 `--provider claude`，可透過 claude.ai 網頁送出文字 prompt 並取回回覆，與既有的 ChatGPT / Gemini 並列。

> 本 PR 已 **rebase 到 upstream/main 0.2.0**。原先配套的 Linux 平台支援（#6）因 maintainer 已在 `94c1912`（0.2.0）自行補上 Linux/WSL Chrome 路徑偵測而關閉，故本 PR 現在**無需另外的 Linux PR**，在 0.2.0 上 macOS / Windows / Linux 皆可直接使用。

## 變更內容

- `Provider` enum 新增 `Claude` variant，補齊全部 provider 設定方法的 Claude 分支（`home_url` / `owns_url` / `ready_check` / `login_check` / `composer` / `send` / `stop` / `assistant` selector）。
- selector 採 `data-testid` / `aria-label` 語意屬性並經 claude.ai 實站校正；完成偵測用 `div[data-is-streaming="false"]`。
- `validate_provider_feature_support` 明確擋下 Claude 第一版尚不支援的 `--image` / `--file` 附件與 `--model` 模型切換（沿用 Gemini image 的 gating 模式，回報清楚訊息）。
- 原先以 `claude` 作為「無效 provider」反例的兩個測試改用 `grok`，claude 設為有效 provider。
- upstream 0.2.0 的 `@Agent` 分段輸入路徑 gate 在 ChatGPT，Claude 走常規送出路徑，無需額外分支。
- `README` / `README.en` / `CHANGELOG` 同步（第一句 provider 列表補上 Claude，回應 review comment）。

## 測試

- `cargo test`：**32 passed**（含 upstream 0.2.0 既有測試 + 新增 Claude 測試）
- `cargo fmt --all -- --check`：通過
- **claude.ai 實機端到端**：送出 → 完成偵測 → 擷取回覆 → 取得 thread link，成功。

## 備註

- 第一版聚焦文字 prompt 的送出與取回；附件與模型切換留待後續。

🤖 Generated with [Claude Code](https://claude.com/claude-code)