### PR TITLE
fix(windows): 在非 verbose 模式下以 PowerShell 包裝 MCP server 並將 stderr 導向 $null

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -708,8 +708,8 @@ fn write_mcp_config(quiet_mcp: bool, headless: bool) -> Result<String, String> {
             ]
         })
     } else if quiet_mcp && cfg!(target_os = "windows") {
-        // Windows: wrap with PowerShell so we can redirect stderr to $null
-        let mut ps_args = vec![
+        // Windows: wrap with cmd.exe so we can redirect stderr to nul
+        let mut cmd_args = vec![
             "-y".to_string(),
             "chrome-devtools-mcp@latest".to_string(),
             "--browser-url=http://127.0.0.1:9223".to_string(),
@@ -719,17 +719,15 @@ fn write_mcp_config(quiet_mcp: bool, headless: bool) -> Result<String, String> {
             format!("\"{}\"", log_path),
         ];
         if headless {
-            ps_args.push("--headless".to_string());
+            cmd_args.push("--headless".to_string());
         }
-        let ps_cmd = format!("npx {} 2>$null", ps_args.join(" "));
+        let cmd_str = format!("npx {} 2>nul", cmd_args.join(" "));
 
         serde_json::json!({
-            "command": "powershell.exe",
+            "command": "cmd.exe",
             "args": [
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                ps_cmd
+                "/c",
+                cmd_str
             ]
         })
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -690,6 +690,7 @@ fn write_mcp_config(quiet_mcp: bool, headless: bool) -> Result<String, String> {
     let config_path = config_dir.to_string_lossy().to_string();
 
     let mut chrome_devtools_server = if quiet_mcp && !cfg!(target_os = "windows") {
+        // Unix: wrap with sh so we can redirect stderr to /dev/null
         let mut sh_cmd = format!(
             "exec npx -y chrome-devtools-mcp@latest --browser-url=http://127.0.0.1:9223 --no-usage-statistics --no-performance-crux --logFile \"{}\"",
             log_path
@@ -704,6 +705,31 @@ fn write_mcp_config(quiet_mcp: bool, headless: bool) -> Result<String, String> {
             "args": [
                 "-c",
                 sh_cmd
+            ]
+        })
+    } else if quiet_mcp && cfg!(target_os = "windows") {
+        // Windows: wrap with PowerShell so we can redirect stderr to $null
+        let mut ps_args = vec![
+            "-y".to_string(),
+            "chrome-devtools-mcp@latest".to_string(),
+            "--browser-url=http://127.0.0.1:9223".to_string(),
+            "--no-usage-statistics".to_string(),
+            "--no-performance-crux".to_string(),
+            "--logFile".to_string(),
+            format!("\"{}\"", log_path),
+        ];
+        if headless {
+            ps_args.push("--headless".to_string());
+        }
+        let ps_cmd = format!("npx {} 2>$null", ps_args.join(" "));
+
+        serde_json::json!({
+            "command": "powershell.exe",
+            "args": [
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                ps_cmd
             ]
         })
     } else {


### PR DESCRIPTION
## 問題說明

關聯 Issue: #4

在 Windows PowerShell 環境中，即使未使用 `--verbose` 參數，仍會在終端機看到 `[chrome-devtools]` 開頭的多行提示訊息：

```
[chrome-devtools] turning off usage statistics. process.env['CI'] || process.env['CHROME_DEVTOOLS_MCP_NO_USAGE_STATISTICS'] is set.
[chrome-devtools] chrome-devtools-mcp exposes content of the browser instance to the MCP clients allowing them to inspect,
[chrome-devtools] debug, and modify any data in the browser or DevTools.
[chrome-devtools] Avoid sharing sensitive or personal information that you do not want to share with MCP clients.
[chrome-devtools] Performance tools may send trace URLs to the Google CrUX API to fetch real-user experience data. To disable, run with --no-performance-crux.
```

## 根本原因

`mcp-cli` 的 `StdioClient::connect()` 會將子進程（`chrome-devtools-mcp`）的 stderr 以 `Stdio::piped()` 捕捉後，無條件透過 `eprint!()` 將每一行輸出至父進程的 stderr：

```rust
eprint!("[{}] {}", server_name_str, line);
```

在 Unix/macOS 上，原有的 `quiet_mcp` 修正已使用 `sh -c` 包裝並追加 `2>/dev/null`，可在子進程層面丟棄 stderr 輸出，讓 `mcp-cli` 捕捉到的 stderr 為空。

然而 **Windows 系統的 `quiet_mcp` 分支未套用等效處理**，導致 stderr 在非 verbose 模式下仍然顯示。

## 修正方式

在 `write_mcp_config()` 函式中，新增 `quiet_mcp && cfg!(target_os = "windows")` 分支，以 PowerShell 包裝 `npx` 指令並在尾端追加 `2>$null`：

| 平台 | 非 verbose 模式（quiet_mcp） |
|------|-------------------------------|
| Unix / macOS | `sh -c 'exec npx ... 2>/dev/null'` |
| **Windows（本次修正）** | `powershell.exe -NoProfile -NonInteractive -Command 'npx ... 2>$null'` |
| 任何平台（verbose 模式） | 直接執行 `npx` / `npx.cmd`，完整顯示輸出 |

同時在 Windows quiet 模式中補上 `--no-usage-statistics` 及 `--no-performance-crux` 參數，與 Unix quiet 模式保持行為一致。

## 測試

- `cargo fmt --all -- --check`：通過 ✅
- `cargo check`：通過 ✅

Fixes #4