### PR TITLE
fix: 修正真實查詢必卡死 — 持久化 MCP session＋修正非 TTY stdin 無限阻塞

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use base64::{Engine as _, engine::general_purpose};
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
-use mcp_cli::McpClient;
+use mcp_cli::{McpClient, McpConnection, ServerConfig, StdioClient};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;
@@ -774,7 +774,7 @@ fn validate_node_version_output(output: &str) -> Result<(), String> {
     }
 
     Err(format!(
-        "Node.js v{major}.{minor}.{patch} is not supported by chrome-devtools-mcp@latest. Supported versions are ^20.19.0, ^22.12.0, or >=23.0.0. Install a current Node.js LTS release, reopen the terminal, and retry."
+        "Node.js v{major}.{minor}.{patch} is not supported by {MCP_PACKAGE_SPEC}. Supported versions are ^20.19.0, ^22.12.0, or >=23.0.0. Install a current Node.js LTS release, reopen the terminal, and retry."
     ))
 }
 
@@ -798,6 +798,12 @@ fn check_node_runtime() -> Result<(), String> {
     validate_node_version_output(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// Pinned chrome-devtools-mcp package spec. `@latest` would make every npx
+/// spawn re-resolve the dist-tag against the npm registry, which was observed
+/// stalling; with mcp-cli's timeout-less request wait that hung whole runs
+/// (2026-07-11). Bump this version deliberately and re-run the e2e check.
+const MCP_PACKAGE_SPEC: &str = "chrome-devtools-mcp@1.5.0";
+
 fn build_chrome_devtools_server_config(
     quiet_mcp: bool,
     headless: bool,
@@ -806,7 +812,7 @@ fn build_chrome_devtools_server_config(
 ) -> Value {
     let mut mcp_args = vec![
         "-y".to_string(),
-        "chrome-devtools-mcp@latest".to_string(),
+        MCP_PACKAGE_SPEC.to_string(),
         "--browser-url=http://127.0.0.1:9223".to_string(),
     ];
     if quiet_mcp {
@@ -1735,13 +1741,135 @@ fn close_ask_chrome_on_debug_port(profile_path: &str) -> Result<bool, String> {
 
 static FORWARD_MCP_STDERR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
 
-fn call_mcp_tool(config_path: &str, tool: &str, args: Value) -> Result<Value, String> {
+/// One MCP session per run: a single long-lived chrome-devtools-mcp child plus
+/// the tokio runtime that drives its background reader tasks.
+///
+/// Upstream called `McpClient::call_tool` per browser action, which spawns a
+/// fresh `npx chrome-devtools-mcp` child for every single action (~50 per
+/// query) and waits on its response without any timeout — one stalled npx
+/// spawn hung the whole run forever (2026-07-11). Reusing one connection
+/// removes the re-spawn churn; `MCP_CALL_TIMEOUT` turns any remaining stall
+/// into a loud, bounded error (see `mcp_error_is_transport` for why the failed
+/// call is not replayed).
+struct McpSession {
+    connection: McpConnection,
+    runtime: tokio::runtime::Runtime,
+    config_path: String,
+}
+
+static MCP_SESSION: std::sync::Mutex<Option<McpSession>> = std::sync::Mutex::new(None);
+
+const MCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(120);
+const MCP_CALL_TIMEOUT: Duration = Duration::from_secs(90);
+const MCP_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn mcp_session_connect(config_path: &str) -> Result<McpSession, String> {
     let client = McpClient::load(Some(config_path))
         .map_err(|e| format!("Failed to load MCP config: {}", e))?;
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    let server_config = client
+        .server_config("chrome-devtools")
+        .map_err(|e| format!("Missing chrome-devtools MCP server config: {}", e))?;
+    // A multi-thread runtime with one worker keeps the connection's background
+    // stdout/stderr reader tasks running between calls (a current-thread
+    // runtime only makes progress inside block_on).
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()
-        .map_err(|e| format!("Failed to create async runtime for MCP call: {}", e))?;
+        .map_err(|e| format!("Failed to create async runtime for MCP session: {}", e))?;
+    let connection = runtime.block_on(async {
+        // Connect the stdio transport directly: mcp-cli's default path first
+        // tries its persistent daemon, which re-execs this binary with
+        // `--daemon` — an entrypoint ask-bridge does not implement — so that
+        // path can only ever fail and fall back.
+        let connect_future = async {
+            match &server_config {
+                ServerConfig::Stdio(stdio_config) => {
+                    StdioClient::connect("chrome-devtools", stdio_config)
+                        .await
+                        .map(McpConnection::Stdio)
+                }
+                _ => client.connect("chrome-devtools").await,
+            }
+        };
+        match tokio::time::timeout(MCP_CONNECT_TIMEOUT, connect_future).await {
+            Err(_) => Err(format!(
+                "Failed to start chrome-devtools MCP server: timed out after {}s",
+                MCP_CONNECT_TIMEOUT.as_secs()
+            )),
+            Ok(result) => {
+                result.map_err(|e| format!("Failed to start chrome-devtools MCP server: {}", e))
+            }
+        }
+    })?;
+    Ok(McpSession {
+        connection,
+        runtime,
+        config_path: config_path.to_string(),
+    })
+}
+
+fn mcp_session_reset(slot: &mut Option<McpSession>) {
+    if let Some(session) = slot.take() {
+        let McpSession {
+            connection,
+            runtime,
+            ..
+        } = session;
+        // Best-effort close (kills the child); if even that stalls, dropping
+        // the runtime stops the background tasks and the orphaned child exits
+        // on stdin EOF.
+        let _ = runtime
+            .block_on(async { tokio::time::timeout(MCP_CLOSE_TIMEOUT, connection.close()).await });
+    }
+}
+
+fn mcp_session_call(
+    slot: &mut Option<McpSession>,
+    config_path: &str,
+    tool: &str,
+    args: Value,
+) -> Result<Value, String> {
+    let needs_connect = slot
+        .as_ref()
+        .map(|session| session.config_path != config_path)
+        .unwrap_or(true);
+    if needs_connect {
+        mcp_session_reset(slot);
+        *slot = Some(mcp_session_connect(config_path)?);
+    }
+    let session = slot.as_ref().expect("session connected above");
+    session.runtime.block_on(async {
+        match tokio::time::timeout(MCP_CALL_TIMEOUT, session.connection.call_tool(tool, args)).await
+        {
+            Err(_) => Err(format!(
+                "MCP tool '{}' timed out after {}s",
+                tool,
+                MCP_CALL_TIMEOUT.as_secs()
+            )),
+            Ok(result) => result.map_err(|e| format!("mcp-cli library call failed: {}", e)),
+        }
+    })
+}
+
+/// Errors that mean the MCP transport itself is dead or wedged: our own
+/// timeouts, or transport-level failures (dead child / closed pipes — exact
+/// phrases from mcp-cli's StdioClient). These earn a session reset so the next
+/// command starts clean. The failed call is deliberately NOT replayed: a
+/// timed-out request may already have executed in the browser (replaying a
+/// submit would double-post), and a fresh chrome-devtools-mcp child forgets
+/// the selected page (a replay could act on the wrong tab). Application-level
+/// tool errors (e.g. a JS exception from evaluate_script) propagate unchanged.
+fn mcp_error_is_transport(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("timed out")
+        || lower.contains("failed to send request to process stdin")
+        || lower.contains("server process exited unexpectedly")
+        || lower.contains("stdio response receiver canceled")
+        || lower.contains("failed to start chrome-devtools mcp server")
+}
+
+fn call_mcp_tool(config_path: &str, tool: &str, args: Value) -> Result<Value, String> {
     let _stderr_guard = if FORWARD_MCP_STDERR.load(std::sync::atomic::Ordering::Relaxed) {
         None
     } else {
@@ -1751,9 +1879,19 @@ fn call_mcp_tool(config_path: &str, tool: &str, args: Value) -> Result<Value, St
         )
     };
 
-    runtime
-        .block_on(async { client.call_tool("chrome-devtools", tool, args).await })
-        .map_err(|e| format!("mcp-cli library call failed: {}", e))
+    let mut slot = MCP_SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match mcp_session_call(&mut slot, config_path, tool, args) {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            if mcp_error_is_transport(&error) {
+                mcp_session_reset(&mut slot);
+                return Err(format!("{} (MCP session was reset; re-run the command)", error));
+            }
+            Err(error)
+        }
+    }
 }
 
 fn parse_pages(text: &str) -> Vec<Page> {
@@ -1965,6 +2103,100 @@ mod tests {
     }
 
     #[test]
+    fn pins_chrome_devtools_mcp_version() {
+        // `@latest` makes every npx spawn re-resolve the dist-tag against the
+        // npm registry; combined with mcp-cli's timeout-less request wait this
+        // hung whole runs (2026-07-11). The package spec must pin a version.
+        let config = build_chrome_devtools_server_config(true, true, "/tmp/mcp.log", false);
+        let args = config["args"].as_array().expect("args array");
+        let pkg = args
+            .iter()
+            .filter_map(|a| a.as_str())
+            .find(|a| a.starts_with("chrome-devtools-mcp"))
+            .expect("chrome-devtools-mcp package argument");
+        assert!(
+            !pkg.ends_with("@latest"),
+            "chrome-devtools-mcp must be version-pinned, got {pkg}"
+        );
+        let version = pkg.rsplit('@').next().unwrap_or_default();
+        assert!(
+            version.chars().next().is_some_and(|c| c.is_ascii_digit()),
+            "expected an explicit pinned version, got {pkg}"
+        );
+    }
+
+    #[test]
+    fn classifies_transport_errors_for_reconnect() {
+        // Transport failures earn a session reset + loud error (exact phrases
+        // from mcp-cli's StdioClient surface inside CliError's `Details:`
+        // line); the call is never replayed — see mcp_error_is_transport...
+        for transport in [
+            "MCP tool 'click' timed out after 90s",
+            "Error [SERVER_CONNECTION_FAILED]: x\n  Details: Failed to send request to process stdin",
+            "Error [TOOL_EXECUTION_FAILED]: x\n  Details: Server process exited unexpectedly. Last stderr:\nnpm error",
+            "Error [SERVER_CONNECTION_FAILED]: x\n  Details: Stdio response receiver canceled",
+            "Failed to start chrome-devtools MCP server: timed out after 120s",
+        ] {
+            assert!(
+                mcp_error_is_transport(transport),
+                "expected transport-class error: {transport}"
+            );
+        }
+        // ...application-level tool errors must NOT reset the session — the
+        // transport is fine and the caller needs the original error.
+        for app_level in [
+            "mcp-cli library call failed: Error [TOOL_EXECUTION_FAILED]: Tool \"click\" execution failed\n  Details: element not found",
+            "mcp-cli library call failed: Error [TOOL_EXECUTION_FAILED]: Tool \"evaluate_script\" execution failed\n  Details: TypeError: x is undefined",
+        ] {
+            assert!(
+                !mcp_error_is_transport(app_level),
+                "expected app-level error to pass through: {app_level}"
+            );
+        }
+    }
+
+    #[test]
+    fn piped_stdin_grace_skips_silent_pipe_when_prompt_argument_present() {
+        // Agent harnesses (Claude Code / Codex) run commands with a non-tty
+        // stdin they may never close; blocking on EOF hung whole runs
+        // (2026-07-11). With a prompt argument in hand, a silent pipe must be
+        // treated as "no piped input" after the grace period.
+        let (_probe_tx, probe_rx) = std::sync::mpsc::channel::<StdinProbe>();
+        let (_data_tx, data_rx) = std::sync::mpsc::channel::<std::io::Result<String>>();
+        let out = recv_piped_stdin(&probe_rx, &data_rx, Duration::from_millis(50), true)
+            .expect("silent pipe should yield empty stdin, not an error");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn piped_stdin_reads_live_pipe_to_eof_when_prompt_argument_present() {
+        // A pipe that delivers data keeps the documented combine behavior:
+        // `cat notes.md | ask-bridge '摘要'` must still append stdin.
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let (data_tx, data_rx) = std::sync::mpsc::channel();
+        probe_tx.send(StdinProbe::Data).unwrap();
+        data_tx.send(Ok("piped context".to_string())).unwrap();
+        let out = recv_piped_stdin(&probe_rx, &data_rx, Duration::from_millis(50), true)
+            .expect("live pipe should be read");
+        assert_eq!(out, "piped context");
+    }
+
+    #[test]
+    fn piped_stdin_waits_unbounded_when_no_prompt_argument() {
+        // Without a prompt argument stdin IS the prompt: keep upstream's
+        // unbounded wait even when data arrives long after any grace window.
+        let (_probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let (data_tx, data_rx) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(120));
+            let _ = data_tx.send(Ok("stdin is the prompt".to_string()));
+        });
+        let out = recv_piped_stdin(&probe_rx, &data_rx, Duration::from_millis(10), false)
+            .expect("unbounded wait should return the piped prompt");
+        assert_eq!(out, "stdin is the prompt");
+    }
+
+    #[test]
     fn builds_direct_quiet_mcp_configs() {
         fn config_args(config: &serde_json::Value) -> Vec<&str> {
             config["args"]
@@ -1986,7 +2218,7 @@ mod tests {
         assert_eq!(verbose_windows["command"].as_str(), Some("npx.cmd"));
         assert_eq!(quiet_unix["command"].as_str(), Some("npx"));
         for required in [
-            "chrome-devtools-mcp@latest",
+            MCP_PACKAGE_SPEC,
             "--browser-url=http://127.0.0.1:9223",
             "--headless",
             "--logFile",
@@ -5106,6 +5338,87 @@ fn print_chrome_diagnostics(profile_path: &str) {
     );
 }
 
+/// How long to wait for a non-tty stdin to produce its first byte (or EOF)
+/// when a prompt argument was already provided. Agent harnesses (Claude Code,
+/// Codex) run commands with a pipe they may never close; blocking on EOF hung
+/// whole runs (2026-07-11).
+const STDIN_PIPE_GRACE: Duration = Duration::from_secs(2);
+
+enum StdinProbe {
+    Data,
+    Eof,
+}
+
+/// Read stdin on a helper thread, signalling the first byte (or EOF) on one
+/// channel and the full content on another, so the caller can bound how long
+/// it waits for a pipe that might never deliver anything.
+fn spawn_stdin_reader() -> (
+    std::sync::mpsc::Receiver<StdinProbe>,
+    std::sync::mpsc::Receiver<std::io::Result<String>>,
+) {
+    let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+    let (data_tx, data_rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let mut stdin = io::stdin();
+        let mut first = [0u8; 1];
+        match stdin.read(&mut first) {
+            Ok(0) => {
+                let _ = probe_tx.send(StdinProbe::Eof);
+                let _ = data_tx.send(Ok(String::new()));
+            }
+            Ok(_) => {
+                let _ = probe_tx.send(StdinProbe::Data);
+                let mut bytes = vec![first[0]];
+                let result = stdin.read_to_end(&mut bytes).and_then(|_| {
+                    String::from_utf8(bytes)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+                });
+                let _ = data_tx.send(result);
+            }
+            Err(e) => {
+                let _ = probe_tx.send(StdinProbe::Eof);
+                let _ = data_tx.send(Err(e));
+            }
+        }
+    });
+    (probe_rx, data_rx)
+}
+
+/// With a prompt argument in hand piped stdin is an optional supplement: wait
+/// up to `grace` for the pipe's first byte, then read a live pipe to EOF as
+/// before; a silent pipe (agent harness holding it open) is treated as "no
+/// piped input". Without a prompt argument stdin IS the prompt, so wait
+/// unbounded exactly like upstream.
+fn recv_piped_stdin(
+    probe_rx: &std::sync::mpsc::Receiver<StdinProbe>,
+    data_rx: &std::sync::mpsc::Receiver<std::io::Result<String>>,
+    grace: Duration,
+    has_prompt_argument: bool,
+) -> std::io::Result<String> {
+    if !has_prompt_argument {
+        // stdin IS the prompt: wait unbounded like upstream, but after the
+        // grace window tell the user what we are blocked on (an agent harness
+        // holding the pipe open would otherwise hang here with no diagnostic).
+        return match data_rx.recv_timeout(grace) {
+            Ok(result) => result,
+            Err(_) => {
+                eprintln!("Waiting for a prompt on stdin (pipe is open; close it or pass a prompt argument)...");
+                data_rx.recv().unwrap_or(Ok(String::new()))
+            }
+        };
+    }
+    match probe_rx.recv_timeout(grace) {
+        Ok(_) => data_rx.recv().unwrap_or(Ok(String::new())),
+        Err(_) => {
+            eprintln!(
+                "No piped stdin data within {}s; continuing with the prompt argument only.",
+                grace.as_secs()
+            );
+            Ok(String::new())
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut cli = Cli::parse();
     if cli.command.is_none() {
@@ -5449,7 +5762,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Check if stdin is a pipe (not a tty)
     if !std::io::stdin().is_terminal() {
-        io::stdin().read_to_string(&mut stdin_prompt)?;
+        let (probe_rx, data_rx) = spawn_stdin_reader();
+        stdin_prompt = recv_piped_stdin(
+            &probe_rx,
+            &data_rx,
+            STDIN_PIPE_GRACE,
+            cli.prompt.is_some(),
+        )?;
     }
 
     let prompt = match cli.prompt {


### PR DESCRIPTION
## 問題

在 agent 環境（Claude Code / Codex 這類把 ask-bridge 當子程序呼叫的 harness）下，任何真實查詢都會永久卡死（觀測到 30 分鐘以上零輸出）；只有秒答型的極短回覆偶爾成功。ChatGPT 與 Gemini 都會發生，卡住的步驟每次不同。

## 根因（兩個疊加的 bug）

**1. 每個瀏覽器動作都重新 spawn 一次 MCP server。**
`call_mcp_tool()` 每次呼叫都 `McpClient::load()` → 連線 → 單一 tool call → kill child。一次查詢約 50 次以上完整的 `npx chrome-devtools-mcp@latest` spawn＋握手循環，而 `@latest` 讓每次 spawn 都可能重新向 npm registry 解析 dist-tag（卡住當下可觀測到 npm arborist `reify.js` 執行中）。

mcp-cli 內建的 persistent daemon 本可避免這件事，但它靠 re-exec `current_exe()` 加 `--daemon` 參數啟動——mcp-cli 自己的 binary 有這個入口，ask-bridge 沒有實作，因此 daemon 每次啟動秒敗、**靜默** fallback 到 per-call spawn。同時 mcp-cli `StdioClient::request()` 的 `rx.await` 沒有任何 timeout——任何一次 spawn／握手卡住，整個 run 就永久吊死。這解釋了卡點隨機：不是某一步壞掉，而是每一步都在重跑同一個脆弱循環。

**2. 非 TTY stdin 無限阻塞。**
`main()` 在送出 prompt 前有 `if !stdin.is_terminal() { read_to_string(...) }`。agent harness 給子程序的 stdin 是一條可能永不關閉的 pipe → 在做任何瀏覽器工作之前就永久阻塞在這行。對照實驗：同一命令加 `< /dev/null` 立即恢復正常。

## 修法

- 新增 `MCP_PACKAGE_SPEC` 常數 pin `chrome-devtools-mcp@1.5.0`，避免每次 spawn 重新解析 `@latest`；升版時改常數即可。
- 新增 `McpSession`：整個 run 共用一條 MCP 連線（直接 `StdioClient::connect`，繞過必敗的 daemon 路徑），以 1-worker 的 multi-thread runtime 讓背景 reader 常駐。每個 call 包 90s timeout、connect 120s、close 5s。
- transport 類錯誤（自身 timeout、child 死亡、pipe 斷）→ **reset session＋明確報錯，不自動重放**：timed-out 的請求可能已在瀏覽器內執行（重放 submit 會重複送出），且新 child 會忘記 selected page（重放可能打到錯的分頁）。應用層錯誤（如 evaluate_script 的 JS 例外）原樣傳遞。
- stdin：reader thread＋首位元組探測。已有 prompt 引數時等 2 秒 grace，安靜的 pipe 視為無輸入並印 stderr 提示；沒有 prompt 引數時 stdin 就是 prompt，維持原本的無限等待（grace 後印一行等待診斷，方便使用者知道在等什麼）。

## 測試與驗證

- ＋5 個單元測試（版本 pin 驗證、transport 錯誤分類、stdin grace 三情境）；本分支 `cargo test` 63 綠、clippy 乾淨。
- e2e（macOS＋Chromium 系瀏覽器）：修復前必卡的多句真實查詢 <40 秒完成；全程觀測只有 1 個 chrome-devtools-mcp child（修復前每個動作 1 個）；17KB 長回覆查詢正常取回。

## 相容性與已知取捨

- 正常互動路徑行為不變；quiet／verbose 的 stderr 處理不變。
- 已提供 prompt 引數時，首位元組 >2 秒才到的慢速 stdin 管線會被略過（有 stderr 警告）——替代方案是在 harness 下永久卡死；此情境建議改用 `--file`。
- 傳了資料但永不 EOF 的 pipe 仍會等待到 EOF（與合法的慢速 producer 本質上無法區分）。

若希望把 MCP 與 stdin 拆成兩個 PR、調整 grace 預設值或改用其他設計，樂意配合修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)