### PR TITLE
feat(session): 支援接續既有 provider 對話

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ home = "0.5"
 mcp-cli = { git = "https://github.com/doggy8088/mcp-cli" }
 gag = "1.0"
 base64 = "0.21"
+url = "2"

--- a/README.en.md
+++ b/README.en.md
@@ -39,6 +39,7 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask-bridge "summarize this"`).
 - **📎 Image & File Attachments**: Attach local images with `--image` (supported on ChatGPT and Claude), or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`.
 - **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4`, Gemini `3.5 Flash`, or Claude `Sonnet`.
+- **Resume Conversations**: Use `--session`, `--session-id`, or `--session-url` to continue an existing provider conversation with a new terminal prompt.
 - **Response Timeout**: Use `--timeout <seconds>` to control how long to wait for a provider response, defaulting to `300` seconds.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
 - **Version Info**: Use `-v` or `--version` to print the current version number.
@@ -207,7 +208,25 @@ ask-bridge "誰是保哥？" --new
 - If the new tab cannot be identified unambiguously, the command stops instead of
   reusing or closing an existing tab.
 
-### 4. Headless Mode (Default: True)
+### 4. Resume an Existing Conversation
+
+Pass either a provider conversation ID or a full conversation URL to continue its
+existing web context:
+
+```bash
+ask-bridge --provider chatgpt --session-id "conversation-uuid" "Continue the previous plan."
+ask-bridge --session-url "https://chatgpt.com/c/conversation-uuid" "Produce the next steps."
+ask-bridge --provider gemini --session "conversation-id" "Continue the analysis."
+```
+
+`--session`, `--session-id`, and `--session-url` are aliases for the same option.
+An ID uses the selected or configured provider to build the conversation URL. A
+full URL identifies its provider automatically. The command stops before opening
+Chrome when an explicitly selected provider conflicts with the URL, the URL does
+not belong to a supported provider, or `--new` is also supplied. Existing tabs
+are preserved.
+
+### 5. Headless Mode (Default: True)
 
 By default, standard queries run Chrome in **headless mode** (`--headless=true`) so that the browser operates silently in the background without stealing your focus or popping up windows.
 
@@ -219,7 +238,7 @@ ask-bridge "誰是保哥？" --headless=false
 
 *Note: `ask-bridge login` always overrides the default and runs in **headful mode** so you can interact with the UI. For other subcommands, pass `--headless=false` when you want a visible browser.*
 
-### 5. Verbose Mode (`--verbose`)
+### 6. Verbose Mode (`--verbose`)
 
 By default, `ask-bridge` runs in a **quiet, clean mode** that hides all background browser-control logs (such as "Checking open Chrome tabs...", "Typing prompt...", etc.) and only displays the final markdown answer. However, it still plays an animated rotating spinner in your terminal while waiting for the provider to generate a response.
 
@@ -236,7 +255,7 @@ This will print every stage of the browser automation:
 - Submitting...
 - Waiting for provider response...
 
-### 6. Response Timeout (`--timeout`)
+### 7. Response Timeout (`--timeout`)
 
 The default wait time is 300 seconds. If a provider takes longer, increase (or decrease) the timeout:
 
@@ -252,7 +271,7 @@ ask-bridge "Short answer" --timeout 60
 
 If the response does not complete within the configured seconds, `ask-bridge` will stop waiting and print a timeout warning.
 
-### 7. Version Info
+### 8. Version Info
 
 Use `-v` or `--version` to print the current version number:
 
@@ -260,7 +279,7 @@ Use `-v` or `--version` to print the current version number:
 ask-bridge -v
 ```
 
-### 8. Piping & Stdin Support
+### 9. Piping & Stdin Support
 
 You can pipe text or files directly into `ask-bridge`:
 
@@ -280,7 +299,7 @@ Or read files:
 cat src/main.rs | ask-bridge "Are there any memory leaks in this Rust code?"
 ```
 
-### 8. Attaching Images or Files
+### 10. Attaching Images or Files
 
 Instead of piping file contents into the prompt, you can upload local files as attachments directly to the selected provider.
 
@@ -312,7 +331,7 @@ You can attach images and documents at the same time:
 ask-bridge "Compare this design image against the spec document and list inconsistencies." --image design.png --file spec.docx
 ```
 
-### 9. Switch Model
+### 11. Switch Model
 
 Use `--model` to automatically switch the provider model before the prompt is sent. Matching is case- and punctuation-insensitive (`-`, `.`, spaces, etc. are ignored).
 
@@ -335,7 +354,7 @@ Available model names (depending on your account entitlements and provider UI):
 
 > If the requested name is not found in the menu, `ask-bridge` reports `Model switch failed: error: model not found in menu` and aborts without submitting the prompt.
 
-### 10. Just Open a Provider
+### 12. Just Open a Provider
 
 To quickly launch the browser and open the selected provider without sending any query:
 
@@ -345,7 +364,7 @@ ask-bridge --provider gemini open
 ask-bridge --provider claude open
 ```
 
-### 11. Close the Browser Instance
+### 13. Close the Browser Instance
 
 To close the Chrome debug profile instance managed by `ask-bridge`:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask-bridge "summarize this"`。
 - **圖片與文件上傳**：可透過 `--image` 附上圖片（支援 ChatGPT 與 Claude），或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入。
 - **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，Gemini 的 `3.5 Flash`、`3.1 Pro`，或 Claude 的 `Sonnet`、`Opus`）。
+- **接續既有對話**：使用 `--session`、`--session-id` 或 `--session-url` 指定既有對話，再從終端機送出新的 prompt。
 - **回應超時**：使用 `--timeout <秒數>` 設定等待回應上限，預設為 `300` 秒。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
 - **版本資訊**：使用 `-v` 或 `--version` 顯示目前版本號。
@@ -205,7 +206,22 @@ ask-bridge "誰是保哥？" --new
 分頁與其他網站分頁都會保留；若無法唯一辨識新分頁，命令會停止且不會改用
 或關閉既有分頁。
 
-### 4. Headless 模式
+### 4. 接續既有對話
+
+使用 provider 對話 ID 或完整對話 URL，可接續網頁端既有的對話脈絡：
+
+```bash
+ask-bridge --provider chatgpt --session-id "conversation-uuid" "請接續先前的規劃。"
+ask-bridge --session-url "https://chatgpt.com/c/conversation-uuid" "請產出下一步計畫。"
+ask-bridge --provider gemini --session "conversation-id" "請繼續分析。"
+```
+
+`--session`、`--session-id` 與 `--session-url` 是相同參數的別名。傳入 ID
+時會依 `--provider` 或全域設定組成 provider 對話 URL；傳入完整 URL 時會辨識
+provider。若同時明確指定不相符的 `--provider`、URL 不屬於支援的 provider，
+或與 `--new` 同時使用，命令會在開啟瀏覽器前停止。既有頁籤不會被關閉。
+
+### 5. Headless 模式
 
 一般提問預設使用 headless Chrome，也就是 `--headless=true`。Chrome 會在背景執行，不會搶走焦點或跳出視窗。
 
@@ -217,7 +233,7 @@ ask-bridge "誰是保哥？" --headless=false
 
 `ask-bridge login` 會強制使用 headful 模式，方便你和瀏覽器 UI 互動；其他 subcommand 若要可見瀏覽器，請明確加上 `--headless=false`。
 
-### 5. Verbose 模式
+### 6. Verbose 模式
 
 預設情況下，`ask-bridge` 只輸出所選 provider 的最終回覆，隱藏背景控制訊息。
 
@@ -235,7 +251,7 @@ Verbose 模式會顯示類似以下流程：
 - 送出訊息。
 - 等待 provider 回覆。
 
-### 6. 回應超時（`--timeout`）
+### 7. 回應超時（`--timeout`）
 
 回答等待預設 300 秒，若 provider 回應時間較長可提高（或降低）等待上限：
 
@@ -251,7 +267,7 @@ ask-bridge "簡短回覆" --timeout 60
 
 超過設定秒數仍未完成時，會輸出超時警告並直接結束回應等待流程。
 
-### 7. 顯示版本
+### 8. 顯示版本
 
 使用 `-v` 或 `--version` 顯示目前版本號：
 
@@ -259,7 +275,7 @@ ask-bridge "簡短回覆" --timeout 60
 ask-bridge -v
 ```
 
-### 8. Pipe 與 stdin
+### 9. Pipe 與 stdin
 
 可透過 pipe 將文字或檔案內容傳入 `ask-bridge`：
 
@@ -279,7 +295,7 @@ cat /Users/will/.copilot/session-state/46cc0f1c-79fd-4622-9548-a0b7fa3794be/rese
 cat src/main.rs | ask-bridge "這段 Rust code 有記憶體洩漏風險嗎？"
 ```
 
-### 8. 附上圖片或文件
+### 10. 附上圖片或文件
 
 除了把檔案內容透過 pipe 傳入 prompt，你也可以直接把本機檔案當作附件上傳給所選 provider。
 
@@ -315,7 +331,7 @@ ask-bridge "請對照這張設計圖與規格文件，指出不一致的地方�
 
 provider 回覆後，可使用 `-i` / `--image-output` 指定生成圖片的下載路徑（資料夾或檔案路徑）。
 
-### 9. 切換模型
+### 11. 切換模型
 
 使用 `--model` 在送出 prompt 前自動切換 provider 的模型。比對時不分大小寫與標點符號（`-`、`.`、空格 等）。
 
@@ -338,7 +354,7 @@ ask-bridge --provider claude "證明這個數學問題。" --model Opus
 
 > 若指定的名稱在選單中找不到，`ask-bridge` 會回報 `Model switch failed: error: model not found in menu` 並中止，不會送出 prompt。
 
-### 10. 只開啟 provider
+### 12. 只開啟 provider
 
 若只想快速開啟瀏覽器並進入所選 provider：
 
@@ -348,7 +364,7 @@ ask-bridge --provider gemini open
 ask-bridge --provider claude open
 ```
 
-### 11. 關閉瀏覽器 instance
+### 13. 關閉瀏覽器 instance
 
 若要關閉 `ask-bridge` 管理的 Chrome debug profile instance：
 
@@ -358,7 +374,7 @@ ask-bridge close
 
 `close` 只會關閉使用 `~/.config/ask-bridge/chrome-profile` 且監聽 debug port `9223` 的 `ask-bridge` Chrome instance；若該 port 被非 `ask-bridge` Chrome 程序占用，會回報錯誤而不會關閉它。
 
-### 12. 更新 ask-bridge
+### 14. 更新 ask-bridge
 
 若要直接自動更新目前安裝的 `ask-bridge`，可直接執行：
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -111,6 +111,23 @@ ask-bridge "開始一個關於 async Rust 的新主題。" --new
 `--new` 會開啟新的所選 provider 對話，而不是重用既有的同 provider 分頁。
 執行前已存在的所有頁籤都會保留；若無法唯一辨識新分頁，命令會停止。
 
+## 接續既有 provider 對話
+
+使用對話 ID：
+
+```sh
+ask-bridge --provider chatgpt --session-id "conversation-uuid" "請接續先前的規劃。"
+```
+
+或直接使用完整對話 URL：
+
+```sh
+ask-bridge --session-url "https://chatgpt.com/c/conversation-uuid" "請產出下一步計畫。"
+```
+
+`--session`、`--session-id` 與 `--session-url` 是相同參數的別名，不能與
+`--new` 同時使用。完整 URL 會自動辨識 provider；既有頁籤都會保留。
+
 ## 透過 pipe 傳入內容
 
 執行：

--- a/skills/ask-bridge/SKILL.md
+++ b/skills/ask-bridge/SKILL.md
@@ -169,6 +169,7 @@ prompt + "\n\n" + stdin
 | `-p`, `--provider <PROVIDER>` | 選擇 provider | 可用 `chatgpt`、`gemini` 或 `claude`；此為 global option，可放在子命令前後；優先權高於全域設定檔 |
 | `--headless[=<HEADLESS>]` | 控制 Chrome 是否 headless | 預設 `true`；要顯示瀏覽器請用 `--headless=false`；不要寫成 `--headless false` |
 | `--new` | 開啟全新 provider 對話 | 會開啟並綁定新的唯一分頁，同時保留所有既有頁籤；用於隔離上下文 |
+| `--session <URL_OR_ID>` | 接續既有 provider 對話 | 可傳完整對話 URL 或對話 ID；`--session-id`、`--session-url` 為別名；不能與 `--new` 同時使用 |
 | `-v`, `-V`, `--version` | 顯示版本 | `-V` 是原始碼中定義的短別名；文件與一般操作優先用 `-v` 或 `--version` |
 | `--verbose` | 顯示瀏覽器自動化流程 | 用於診斷 provider UI、登入、上傳、模型切換或等待回覆問題 |
 | `-o`, `--output <FILE>` | 將最終 Markdown 回覆寫入檔案 | 同時仍會在終端機輸出渲染結果；適合保留研究紀錄 |
@@ -334,6 +335,16 @@ ask-bridge --provider claude '快速摘要這份文件。' --model Haiku
 ```sh
 ask-bridge '請只根據本次輸入分析，不要沿用既有對話脈絡。' --new
 ```
+
+需要沿用網頁端既有對話脈絡時，傳入對話 ID 或完整 URL：
+
+```sh
+ask-bridge --provider chatgpt --session-id 'conversation-uuid' '請接續先前的規劃。'
+ask-bridge --session-url 'https://chatgpt.com/c/conversation-uuid' '請產出下一步計畫。'
+```
+
+完整 URL 會辨識 provider；若同時明確指定不同的 `--provider`，命令會停止。
+不要使用對話標題猜測 session，也不要將 `--session` 與 `--new` 同時使用。
 
 一般提問預設 `--headless=true`。需要觀察 Chrome 操作時使用：
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
+use url::Url;
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -87,17 +88,49 @@ impl Provider {
     }
 
     fn owns_url(self, url: &str) -> bool {
-        match self {
-            Provider::ChatGpt => url.contains("chatgpt.com"),
-            Provider::Gemini => url.contains("gemini.google.com"),
-            Provider::Claude => url.contains("claude.ai"),
-        }
+        Self::from_url(url) == Some(self)
     }
 
     fn from_url(url: &str) -> Option<Self> {
-        [Provider::ChatGpt, Provider::Gemini, Provider::Claude]
-            .into_iter()
-            .find(|provider| provider.owns_url(url))
+        let parsed = Url::parse(url).ok()?;
+        if parsed.scheme() != "https" {
+            return None;
+        }
+
+        match parsed.host_str()?.to_ascii_lowercase().as_str() {
+            "chatgpt.com" | "www.chatgpt.com" => Some(Provider::ChatGpt),
+            "gemini.google.com" => Some(Provider::Gemini),
+            "claude.ai" | "www.claude.ai" => Some(Provider::Claude),
+            _ => None,
+        }
+    }
+
+    fn conversation_url_from_id(self, session_id: &str) -> String {
+        match self {
+            Provider::ChatGpt => format!("https://chatgpt.com/c/{session_id}"),
+            Provider::Gemini => format!("https://gemini.google.com/app/{session_id}"),
+            Provider::Claude => format!("https://claude.ai/chat/{session_id}"),
+        }
+    }
+
+    fn owns_conversation_url(self, url: &Url) -> bool {
+        if Self::from_url(url.as_str()) != Some(self) {
+            return false;
+        }
+
+        let path_segments: Vec<&str> = url
+            .path_segments()
+            .map(|segments| segments.filter(|segment| !segment.is_empty()).collect())
+            .unwrap_or_default();
+        let marker = match self {
+            Provider::ChatGpt => "c",
+            Provider::Gemini => "app",
+            Provider::Claude => "chat",
+        };
+
+        path_segments
+            .windows(2)
+            .any(|segments| segments[0] == marker && !segments[1].is_empty())
     }
 
     fn ready_check_js(self) -> &'static str {
@@ -449,6 +482,15 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     new: bool,
 
+    /// Resume an existing conversation by provider session ID or full conversation URL.
+    #[arg(
+        long = "session",
+        visible_aliases = ["session-id", "session-url"],
+        value_name = "URL_OR_ID",
+        conflicts_with = "new"
+    )]
+    session: Option<String>,
+
     /// Print version information.
     #[arg(
         long = "version",
@@ -743,6 +785,55 @@ fn unique_new_page_id(before: &[Page], after: &[Page]) -> Result<usize, String> 
             new_page_ids
         )),
     }
+}
+
+fn resolve_session_target(
+    selected_provider: Provider,
+    provider_was_explicit: bool,
+    session: &str,
+) -> Result<(Provider, String), String> {
+    let session = session.trim();
+    if session.is_empty() {
+        return Err("Session ID or URL cannot be empty".to_string());
+    }
+
+    if let Ok(url) = Url::parse(session) {
+        let session_provider = Provider::from_url(url.as_str()).ok_or_else(|| {
+            "Session URL must use HTTPS and belong to chatgpt.com, gemini.google.com, or claude.ai"
+                .to_string()
+        })?;
+        if !session_provider.owns_conversation_url(&url) {
+            return Err(format!(
+                "URL is not a supported {} conversation URL",
+                session_provider.display_name()
+            ));
+        }
+        if provider_was_explicit && session_provider != selected_provider {
+            return Err(format!(
+                "Session URL belongs to {}, but --provider selected {}",
+                session_provider.display_name(),
+                selected_provider.display_name()
+            ));
+        }
+
+        return Ok((session_provider, url.to_string()));
+    }
+
+    if session.len() > 256
+        || !session
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return Err(
+            "Session ID may contain only ASCII letters, digits, hyphens, and underscores"
+                .to_string(),
+        );
+    }
+
+    Ok((
+        selected_provider,
+        selected_provider.conversation_url_from_id(session),
+    ))
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2070,6 +2161,13 @@ fn render_markdown(markdown: &str, use_glow: bool) -> Result<(), String> {
 }
 
 fn validate_provider_feature_support(provider: Provider, cli: &Cli) -> Result<(), String> {
+    if cli.session.is_some() && cli.command.is_some() {
+        return Err(
+            "--session is supported only for a prompt invocation, not with a subcommand"
+                .to_string(),
+        );
+    }
+
     if provider == Provider::Gemini && !cli.images.is_empty() {
         return Err(
             "Gemini image attachments are not supported yet. Use --file for Gemini document attachments."
@@ -2482,6 +2580,31 @@ mod tests {
     }
 
     #[test]
+    fn parses_session_id_alias_and_rejects_new_session_conflict() {
+        let cli = Cli::try_parse_from([
+            "ask-bridge",
+            "--provider",
+            "chatgpt",
+            "--session-id",
+            "conversation-123",
+            "continue",
+        ])
+        .unwrap();
+        assert_eq!(cli.session.as_deref(), Some("conversation-123"));
+
+        assert!(
+            Cli::try_parse_from([
+                "ask-bridge",
+                "--new",
+                "--session",
+                "conversation-123",
+                "continue",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
     fn maps_provider_urls() {
         assert_eq!(
             Provider::from_url("https://chatgpt.com/c/abc"),
@@ -2496,6 +2619,67 @@ mod tests {
             Some(Provider::Claude)
         );
         assert_eq!(Provider::from_url("https://example.com"), None);
+        assert_eq!(
+            Provider::from_url("https://example.com/?next=https://chatgpt.com/c/abc"),
+            None
+        );
+        assert_eq!(Provider::from_url("http://chatgpt.com/c/abc"), None);
+    }
+
+    #[test]
+    fn resolves_session_ids_for_each_provider() {
+        assert_eq!(
+            resolve_session_target(Provider::ChatGpt, true, "chat-123").unwrap(),
+            (
+                Provider::ChatGpt,
+                "https://chatgpt.com/c/chat-123".to_string()
+            )
+        );
+        assert_eq!(
+            resolve_session_target(Provider::Gemini, true, "gemini_123").unwrap(),
+            (
+                Provider::Gemini,
+                "https://gemini.google.com/app/gemini_123".to_string()
+            )
+        );
+        assert_eq!(
+            resolve_session_target(Provider::Claude, true, "claude-123").unwrap(),
+            (
+                Provider::Claude,
+                "https://claude.ai/chat/claude-123".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn session_url_infers_provider_unless_cli_provider_conflicts() {
+        let target =
+            resolve_session_target(Provider::Gemini, false, "https://chatgpt.com/c/chat-123")
+                .unwrap();
+        assert_eq!(target.0, Provider::ChatGpt);
+        assert_eq!(target.1, "https://chatgpt.com/c/chat-123");
+
+        let error =
+            resolve_session_target(Provider::Gemini, true, "https://chatgpt.com/c/chat-123")
+                .unwrap_err();
+        assert!(error.contains("but --provider selected Gemini"));
+    }
+
+    #[test]
+    fn rejects_invalid_session_urls_and_ids() {
+        for invalid in [
+            "https://example.com/c/chat-123",
+            "https://chatgpt.com/",
+            "https://gemini.google.com/app",
+            "https://claude.ai/chat/",
+            "../chat-123",
+            "chat/123",
+        ] {
+            assert!(
+                resolve_session_target(Provider::ChatGpt, false, invalid).is_err(),
+                "expected {invalid:?} to be rejected"
+            );
+        }
     }
 
     #[test]
@@ -3360,11 +3544,11 @@ fn open_url_tab(
         .and_then(|t| t.as_str())
         .ok_or_else(|| format!("Invalid list_pages response structure: {:?}", list_res))?;
 
-    let pages = parse_pages(text);
-    if pages.len() == 1
-        && (pages[0].url == "about:blank"
-            || pages[0].url.contains("new-tab-page")
-            || pages[0].url.contains("chrome://welcome"))
+    let pages_before = parse_pages(text);
+    let target_page_id = if pages_before.len() == 1
+        && (pages_before[0].url == "about:blank"
+            || pages_before[0].url.contains("new-tab-page")
+            || pages_before[0].url.contains("chrome://welcome"))
     {
         call_mcp_tool(
             config_path,
@@ -3373,6 +3557,7 @@ fn open_url_tab(
                 "url": url
             }),
         )?;
+        pages_before[0].id
     } else {
         call_mcp_tool(
             config_path,
@@ -3381,9 +3566,6 @@ fn open_url_tab(
                 "url": url
             }),
         )?;
-    }
-
-    for _ in 0..20 {
         let refreshed_pages_res = call_mcp_tool(config_path, "list_pages", serde_json::json!({}))?;
         let refreshed_text = refreshed_pages_res
             .get("content")
@@ -3397,34 +3579,18 @@ fn open_url_tab(
                     refreshed_pages_res
                 )
             })?;
-
         let refreshed_pages = parse_pages(refreshed_text);
-        if let Some(page) = refreshed_pages.iter().find(|page| page.url == url) {
-            call_mcp_tool(
-                config_path,
-                "select_page",
-                serde_json::json!({
-                    "pageId": page.id,
-                    "bringToFront": !headless
-                }),
-            )?;
+        unique_new_page_id(&pages_before, &refreshed_pages)?
+    };
 
-            for stale_page in refreshed_pages.iter().filter(|p| p.id != page.id) {
-                let _ = call_mcp_tool(
-                    config_path,
-                    "close_page",
-                    serde_json::json!({
-                        "pageId": stale_page.id
-                    }),
-                );
-            }
-
-            let page_provider = Provider::from_url(url).unwrap_or(provider);
-            return wait_for_page_load(config_path, page_provider, verbose);
-        }
-
-        thread::sleep(Duration::from_millis(250));
-    }
+    call_mcp_tool(
+        config_path,
+        "select_page",
+        serde_json::json!({
+            "pageId": target_page_id,
+            "bringToFront": !headless
+        }),
+    )?;
 
     let page_provider = Provider::from_url(url).unwrap_or(provider);
     wait_for_page_load(config_path, page_provider, verbose)
@@ -5561,12 +5727,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let provider = match resolve_provider(cli.provider) {
+    let mut provider = match resolve_provider(cli.provider) {
         Ok(provider) => provider,
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);
         }
+    };
+
+    let session_target = match cli.session.as_deref() {
+        Some(session) => match resolve_session_target(provider, cli.provider.is_some(), session) {
+            Ok(target) => {
+                provider = target.0;
+                Some(target)
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        },
+        None => None,
     };
 
     if let Err(e) = validate_provider_feature_support(provider, &cli) {
@@ -5902,7 +6082,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(0);
     }
 
-    if let Err(e) = ensure_provider_tab(
+    if let Some((session_provider, session_url)) = &session_target {
+        if let Err(e) = open_url_tab(
+            &config_path,
+            *session_provider,
+            session_url,
+            is_headless,
+            command_verbose,
+        ) {
+            eprintln!(
+                "Error opening {} session: {}",
+                session_provider.display_name(),
+                e
+            );
+            std::process::exit(1);
+        }
+    } else if let Err(e) = ensure_provider_tab(
         &config_path,
         provider,
         cli.new,


### PR DESCRIPTION
## 問題

目前一般問答只能重用自動選取的 provider 分頁或使用 `--new` 建立新對話，無法從 CLI 指定既有歷史對話後繼續送出 prompt。

## 實作

- 新增 `--session <URL_OR_ID>`，並提供 `--session-id`、`--session-url` 別名。
- ID 依所選 provider 組成 ChatGPT、Gemini 或 Claude 對話 URL。
- 完整 URL 會安全解析 HTTPS host 與 provider 對話路徑，並自動辨識 provider。
- 明確指定的 provider 與 URL 不符、ID 格式不合法或與 `--new` 同時使用時，在瀏覽器啟動前失敗。
- 指定對話會綁定新開啟的 page ID，保留所有既有頁籤。
- provider URL 擁有權判斷改為精確 host 比對，避免 query 字串冒充合法 provider。
- 更新中英文 README、快速入門與 Agent Skill。

## 驗證

- `cargo test`：70 項測試通過
- `npm test`：4 項測試通過
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --bin ask-bridge -- --help`
- `git diff --check`

Fixes #13