### PR TITLE
fix(windows): 驗證安裝目標並優先正式路徑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,17 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo test
       - run: npm test
+
+  windows-installer:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm test
+      - name: Validate PowerShell installer syntax
+        shell: pwsh
+        run: |
+          $source = Get-Content install.ps1 -Raw
+          $null = [scriptblock]::Create($source)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,17 @@ jobs:
             throw "Missing updater binary: $updateBinary"
           }
           if ("${{ runner.os }}" -eq "Windows") {
-            $stream = [System.IO.File]::OpenRead($binary)
-            try {
-              $firstByte = $stream.ReadByte()
-              $secondByte = $stream.ReadByte()
-            } finally {
-              $stream.Dispose()
-            }
-            if ($firstByte -ne 0x4D -or $secondByte -ne 0x5A) {
-              throw "Windows release binary is not a PE executable (missing MZ header)"
+            foreach ($windowsBinary in @($binary, $updateBinary)) {
+              $stream = [System.IO.File]::OpenRead($windowsBinary)
+              try {
+                $firstByte = $stream.ReadByte()
+                $secondByte = $stream.ReadByte()
+              } finally {
+                $stream.Dispose()
+              }
+              if ($firstByte -ne 0x4D -or $secondByte -ne 0x5A) {
+                throw "Windows release binary '$windowsBinary' is not a PE executable (missing MZ header)"
+              }
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
           if (!(Test-Path $updateBinary)) {
             throw "Missing updater binary: $updateBinary"
           }
+          if ("${{ runner.os }}" -eq "Windows") {
+            $stream = [System.IO.File]::OpenRead($binary)
+            try {
+              $firstByte = $stream.ReadByte()
+              $secondByte = $stream.ReadByte()
+            } finally {
+              $stream.Dispose()
+            }
+            if ($firstByte -ne 0x4D -or $secondByte -ne 0x5A) {
+              throw "Windows release binary is not a PE executable (missing MZ header)"
+            }
+          }
+
+          $versionOutput = & $binary --version
+          if ($LASTEXITCODE -ne 0 -or "$versionOutput" -notmatch '^ask-bridge\s+\d+\.\d+\.\d+') {
+            throw "Release binary failed version smoke test: $versionOutput"
+          }
 
           New-Item -ItemType Directory -Force dist | Out-Null
           $archive = "dist/ask-bridge-${{ matrix.target }}.${{ matrix.ext }}"

--- a/README.en.md
+++ b/README.en.md
@@ -91,6 +91,10 @@ irm https://raw.githubusercontent.com/doggy8088/ask-bridge/main/install.ps1 | ie
 > [!NOTE]
 > Make sure the installation path (`~/.local/bin` for macOS/Linux, and `$HOME\.local\bin` for Windows) is added to your system's `PATH` environment variable.
 > The formal CLI command is `ask-bridge`; the installer also provides `ask` as a backward-compatible alias. The examples below use `ask-bridge`.
+> The Windows installer verifies that the download is a PE executable, runs a
+> `--version` smoke test, and puts the official install directory first in User
+> PATH. Run `where.exe ask-bridge` and confirm that the first result is
+> `$HOME\.local\bin\ask-bridge.exe`.
 
 ### 2. Build & Install from Source (For Developers)
 

--- a/README.en.md
+++ b/README.en.md
@@ -93,8 +93,8 @@ irm https://raw.githubusercontent.com/doggy8088/ask-bridge/main/install.ps1 | ie
 > The formal CLI command is `ask-bridge`; the installer also provides `ask` as a backward-compatible alias. The examples below use `ask-bridge`.
 > The Windows installer verifies that the download is a PE executable, runs a
 > `--version` smoke test, and puts the official install directory first in User
-> PATH. Run `where.exe ask-bridge` and confirm that the first result is
-> `$HOME\.local\bin\ask-bridge.exe`.
+> PATH. Run `where.exe ask-bridge` and confirm that the first expanded path ends
+> with `\.local\bin\ask-bridge.exe`.
 
 ### 2. Build & Install from Source (For Developers)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ irm https://raw.githubusercontent.com/doggy8088/ask-bridge/main/install.ps1 | ie
 > [!NOTE]
 > 請確保安裝路徑（macOS/Linux 為 `~/.local/bin`；Windows 為 `$HOME\.local\bin`）已加入您的系統 `PATH` 環境變數中。
 > 正式 CLI 命令為 `ask-bridge`；安裝流程也會提供 `ask` 作為向後相容 alias。以下範例皆以 `ask-bridge` 為準。
+> Windows 安裝程式會驗證下載檔為 PE 執行檔、執行 `--version` smoke test，
+> 並把正式安裝目錄放在 User PATH 最前面。可用 `where.exe ask-bridge`
+> 確認第一筆結果為 `$HOME\.local\bin\ask-bridge.exe`。
 
 ### 2. 從原始碼建置與安裝 (適用於開發者)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ irm https://raw.githubusercontent.com/doggy8088/ask-bridge/main/install.ps1 | ie
 > 正式 CLI 命令為 `ask-bridge`；安裝流程也會提供 `ask` 作為向後相容 alias。以下範例皆以 `ask-bridge` 為準。
 > Windows 安裝程式會驗證下載檔為 PE 執行檔、執行 `--version` smoke test，
 > 並把正式安裝目錄放在 User PATH 最前面。可用 `where.exe ask-bridge`
-> 確認第一筆結果為 `$HOME\.local\bin\ask-bridge.exe`。
+> 確認第一筆展開後的完整路徑結尾為 `\.local\bin\ask-bridge.exe`。
 
 ### 2. 從原始碼建置與安裝 (適用於開發者)
 

--- a/install.ps1
+++ b/install.ps1
@@ -122,6 +122,80 @@ function Copy-ItemWithRetry {
     }
 }
 
+function Assert-WindowsExecutable {
+    param(
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $firstByte = $stream.ReadByte()
+        $secondByte = $stream.ReadByte()
+    } finally {
+        $stream.Dispose()
+    }
+
+    if ($firstByte -ne 0x4D -or $secondByte -ne 0x5A) {
+        throw "Binary '$Path' is not a Windows PE executable (missing MZ header). Refusing to install a mismatched platform artifact."
+    }
+}
+
+function Confirm-AskBridgeBinary {
+    param(
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    Assert-WindowsExecutable -Path $Path
+    $versionOutput = & $Path --version 2>&1
+    $versionExitCode = $LASTEXITCODE
+    $versionText = ($versionOutput | Out-String).Trim()
+    if ($versionExitCode -ne 0) {
+        throw "Installed ask-bridge binary failed its version check with exit code $versionExitCode`: $versionText"
+    }
+    if ($versionText -notmatch '^ask-bridge\s+\d+\.\d+\.\d+') {
+        throw "Installed ask-bridge binary returned unexpected version output: '$versionText'"
+    }
+}
+
+function Set-AskBridgePathPriority {
+    param(
+        [Parameter(Mandatory)] [string] $InstallDir
+    )
+
+    $installKey = $InstallDir.Trim().TrimEnd([char[]]"\/")
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $userEntries = @(
+        $userPath -split ';' |
+            Where-Object {
+                $_ -and $_.Trim().TrimEnd([char[]]"\/") -ine $installKey
+            }
+    )
+    $newUserPath = (@($InstallDir) + $userEntries) -join ';'
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+
+    $processEntries = @(
+        $env:Path -split ';' |
+            Where-Object {
+                $_ -and $_.Trim().TrimEnd([char[]]"\/") -ine $installKey
+            }
+    )
+    $env:Path = (@($InstallDir) + $processEntries) -join ';'
+}
+
+function Confirm-AskBridgeCommandResolution {
+    param(
+        [Parameter(Mandatory)] [string] $ExpectedPath
+    )
+
+    $resolved = Get-Command ask-bridge.exe -CommandType Application -ErrorAction Stop |
+        Select-Object -First 1
+    $resolvedPath = [System.IO.Path]::GetFullPath($resolved.Source)
+    $expectedFullPath = [System.IO.Path]::GetFullPath($ExpectedPath)
+    if ($resolvedPath -ine $expectedFullPath) {
+        throw "The 'ask-bridge' command resolves to '$resolvedPath' instead of the newly installed '$expectedFullPath'."
+    }
+}
+
 # 1. Check Node.js and npx
 $nodeCheck = Get-Command node -ErrorAction SilentlyContinue
 $npxCheck = Get-Command npx -ErrorAction SilentlyContinue
@@ -229,6 +303,8 @@ if ($Local) {
         Write-Error "Local updater binary not found at '$LocalUpdatePath'. Check repository permissions and build output path."
         exit 1
     }
+    Assert-WindowsExecutable -Path $LocalPath
+    Assert-WindowsExecutable -Path $LocalUpdatePath
 
     $InstallDir = Join-Path $HOME ".local\bin"
     if (-not (Test-Path $InstallDir)) {
@@ -245,21 +321,10 @@ if ($Local) {
     Copy-ItemWithRetry -Source $ResolvedLocalPath -Destination $AliasPath
     Copy-ItemWithRetry -Source $ResolvedLocalUpdatePath -Destination $UpdatePath
 
-    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $CleanPathList = $UserPath -split ';'
-
-    if ($CleanPathList -notcontains $InstallDir) {
-        Write-Host "Adding $InstallDir to User PATH..." -ForegroundColor Cyan
-        $NewPath = $UserPath
-        if ($NewPath -and -not $NewPath.EndsWith(';')) {
-            $NewPath += ";"
-        }
-        $NewPath += $InstallDir
-        [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
-        
-        $env:Path = $env:Path + ";" + $InstallDir
-        Write-Host "Successfully added to PATH. You may need to restart your terminal to apply." -ForegroundColor Green
-    }
+    Confirm-AskBridgeBinary -Path $DestPath
+    Write-Host "Putting $InstallDir first in User PATH..." -ForegroundColor Cyan
+    Set-AskBridgePathPriority -InstallDir $InstallDir
+    Confirm-AskBridgeCommandResolution -ExpectedPath $DestPath
 
     Write-Host "Successfully installed! You can now use the 'ask-bridge' command. The 'ask' alias is also available." -ForegroundColor Green
     exit 0
@@ -301,6 +366,10 @@ try {
         exit 1
     }
     $UpdateExePath = Get-ChildItem -Path $TempDir -Recurse -Filter "ask-bridge-update.exe" | Select-Object -First 1
+    Assert-WindowsExecutable -Path $ExePath.FullName
+    if ($UpdateExePath) {
+        Assert-WindowsExecutable -Path $UpdateExePath.FullName
+    }
 
     # Copy to destination as ask-bridge.exe and keep ask.exe as an alias.
     $DestPath = Join-Path $InstallDir "ask-bridge.exe"
@@ -316,6 +385,7 @@ try {
     } else {
         Write-Host "Warning: ask-bridge-update.exe not found in archive; update helper unavailable." -ForegroundColor Yellow
     }
+    Confirm-AskBridgeBinary -Path $DestPath
 }
 finally {
     # Clean up temp
@@ -324,22 +394,9 @@ finally {
     }
 }
 
-# 7. Check/Add to PATH
-$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-$CleanPathList = $UserPath -split ';'
-
-if ($CleanPathList -notcontains $InstallDir) {
-    Write-Host "Adding $InstallDir to User PATH..." -ForegroundColor Cyan
-    $NewPath = $UserPath
-    if ($NewPath -and -not $NewPath.EndsWith(';')) {
-        $NewPath += ";"
-    }
-    $NewPath += $InstallDir
-    [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
-    
-    # Update current session path
-    $env:Path = $env:Path + ";" + $InstallDir
-    Write-Host "Successfully added to PATH. You may need to restart your terminal to apply." -ForegroundColor Green
-}
+# 7. Put the verified installation first in PATH and ensure command resolution.
+Write-Host "Putting $InstallDir first in User PATH..." -ForegroundColor Cyan
+Set-AskBridgePathPriority -InstallDir $InstallDir
+Confirm-AskBridgeCommandResolution -ExpectedPath $DestPath
 
 Write-Host "Successfully installed! You can now use the 'ask-bridge' command. The 'ask' alias is also available." -ForegroundColor Green

--- a/install.ps1
+++ b/install.ps1
@@ -146,8 +146,12 @@ function Confirm-AskBridgeBinary {
     )
 
     Assert-WindowsExecutable -Path $Path
-    $versionOutput = & $Path --version 2>&1
-    $versionExitCode = $LASTEXITCODE
+    try {
+        $versionOutput = & $Path --version 2>&1
+        $versionExitCode = $LASTEXITCODE
+    } catch {
+        throw "Installed ask-bridge binary could not start: $($_.Exception.Message)"
+    }
     $versionText = ($versionOutput | Out-String).Trim()
     if ($versionExitCode -ne 0) {
         throw "Installed ask-bridge binary failed its version check with exit code $versionExitCode`: $versionText"
@@ -192,7 +196,7 @@ function Confirm-AskBridgeCommandResolution {
     $resolvedPath = [System.IO.Path]::GetFullPath($resolved.Source)
     $expectedFullPath = [System.IO.Path]::GetFullPath($ExpectedPath)
     if ($resolvedPath -ine $expectedFullPath) {
-        throw "The 'ask-bridge' command resolves to '$resolvedPath' instead of the newly installed '$expectedFullPath'."
+        throw "The 'ask-bridge.exe' command resolves to '$resolvedPath' instead of the newly installed '$expectedFullPath'."
     }
 }
 

--- a/npm/postinstall.cjs
+++ b/npm/postinstall.cjs
@@ -5,9 +5,12 @@ const { createHash } = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 const {
   chmodSync,
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  openSync,
+  readSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -73,8 +76,16 @@ function verifyChecksum(filePath, checksumText) {
 }
 
 function verifyBinaryFormat(filePath, platform = process.platform) {
-  const header = readFileSync(filePath).subarray(0, 4);
-  const magic = header.toString('hex');
+  const header = Buffer.alloc(4);
+  const descriptor = openSync(filePath, 'r');
+  let bytesRead;
+  try {
+    bytesRead = readSync(descriptor, header, 0, header.length, 0);
+  } finally {
+    closeSync(descriptor);
+  }
+  const binaryHeader = header.subarray(0, bytesRead);
+  const magic = binaryHeader.toString('hex');
   const supportedMagic = {
     win32: ['4d5a'],
     linux: ['7f454c46'],

--- a/npm/postinstall.cjs
+++ b/npm/postinstall.cjs
@@ -72,6 +72,52 @@ function verifyChecksum(filePath, checksumText) {
   }
 }
 
+function verifyBinaryFormat(filePath, platform = process.platform) {
+  const header = readFileSync(filePath).subarray(0, 4);
+  const magic = header.toString('hex');
+  const supportedMagic = {
+    win32: ['4d5a'],
+    linux: ['7f454c46'],
+    darwin: [
+      'feedface',
+      'cefaedfe',
+      'feedfacf',
+      'cffaedfe',
+      'cafebabe',
+      'bebafeca',
+      'cafebabf',
+      'bfbafeca',
+    ],
+  };
+  const expected = supportedMagic[platform];
+  if (!expected) {
+    throw new Error(`Unsupported platform for binary verification: ${platform}`);
+  }
+  if (!expected.some((prefix) => magic.startsWith(prefix))) {
+    throw new Error(
+      `Downloaded binary format does not match ${platform} (header: ${magic || 'empty'})`,
+    );
+  }
+}
+
+function verifyInstalledBinary(filePath, platform = process.platform) {
+  verifyBinaryFormat(filePath, platform);
+  const result = spawnSync(filePath, ['--version'], { encoding: 'utf8' });
+  if (result.error) {
+    throw new Error(`Installed binary could not start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    throw new Error(
+      `Installed binary failed its version check with exit code ${result.status}${detail ? `: ${detail}` : ''}`,
+    );
+  }
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  if (!/^ask-bridge\s+\d+\.\d+\.\d+/.test(output)) {
+    throw new Error(`Installed binary returned unexpected version output: ${output || '(empty)'}`);
+  }
+}
+
 function download(url, destination, redirectsRemaining = 5) {
   return new Promise((resolve, reject) => {
     get(url, (res) => {
@@ -129,9 +175,11 @@ function findExtractedBinary(dir, binName = BIN_NAME) {
 function installFromLocalBuild() {
   const localRelease = join(PACKAGE_ROOT, 'target', 'release', BIN_NAME);
   if (!existsSync(localRelease)) return false;
+  verifyBinaryFormat(localRelease);
   mkdirSync(BIN_DIR, { recursive: true });
   copyFileSync(localRelease, DEST);
   chmodSync(DEST, 0o755);
+  verifyInstalledBinary(DEST);
   return true;
 }
 
@@ -151,9 +199,11 @@ async function installFromRelease() {
   extract(archivePath, tmpDir);
 
   const extracted = findExtractedBinary(tmpDir);
+  verifyBinaryFormat(extracted);
   mkdirSync(BIN_DIR, { recursive: true });
   copyFileSync(extracted, DEST);
   chmodSync(DEST, 0o755);
+  verifyInstalledBinary(DEST);
   rmSync(tmpDir, { recursive: true, force: true });
 }
 
@@ -195,5 +245,7 @@ module.exports = {
   platformKey,
   releaseBaseUrl,
   sha256,
+  verifyBinaryFormat,
   verifyChecksum,
+  verifyInstalledBinary,
 };

--- a/skills/ask-bridge/SKILL.md
+++ b/skills/ask-bridge/SKILL.md
@@ -51,7 +51,7 @@ where.exe ask-bridge
 ask-bridge --version
 ```
 
-第一筆路徑應為 `$HOME\.local\bin\ask-bridge.exe`。若其他舊命令排在前面，
+第一筆展開後的完整路徑結尾應為 `\.local\bin\ask-bridge.exe`。若其他舊命令排在前面，
 重新執行官方 `install.ps1`；安裝程式會驗證 Windows PE 格式與版本輸出，
 並將正式安裝目錄移到 User PATH 最前面。
 

--- a/skills/ask-bridge/SKILL.md
+++ b/skills/ask-bridge/SKILL.md
@@ -44,6 +44,17 @@ Node.js 必須符合 `^20.19.0`、`^22.12.0` 或 `>=23.0.0`。執行瀏覽器操
 
 若找不到 `ask-bridge`，在 ask-bridge 專案中可先使用既有安裝流程、`cargo run --bin ask-bridge --`，或建置後的 `target/release/ask-bridge`；不要臆測使用者環境已完成設定。
 
+在 Windows 安裝或更新後，額外確認實際命令來源：
+
+```powershell
+where.exe ask-bridge
+ask-bridge --version
+```
+
+第一筆路徑應為 `$HOME\.local\bin\ask-bridge.exe`。若其他舊命令排在前面，
+重新執行官方 `install.ps1`；安裝程式會驗證 Windows PE 格式與版本輸出，
+並將正式安裝目錄移到 User PATH 最前面。
+
 ## 全域設定檔
 
 `ask-bridge` 會讀取全域設定檔：

--- a/tests/postinstall.test.cjs
+++ b/tests/postinstall.test.cjs
@@ -12,6 +12,7 @@ const {
   platformKey,
   releaseBaseUrl,
   sha256,
+  verifyBinaryFormat,
   verifyChecksum,
 } = require('../npm/postinstall.cjs');
 
@@ -40,4 +41,28 @@ test('verifies sha256 checksums', () => {
   const digest = sha256(file);
   verifyChecksum(file, `${digest}  sample.txt`);
   assert.throws(() => verifyChecksum(file, '0'.repeat(64)), /Checksum mismatch/);
+});
+
+test('verifies native binary formats before installation', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ask-bridge-format-'));
+  const windowsBinary = join(dir, 'ask-bridge.exe');
+  const linuxBinary = join(dir, 'ask-bridge-linux');
+  const macBinary = join(dir, 'ask-bridge-macos');
+
+  writeFileSync(windowsBinary, Buffer.from([0x4d, 0x5a, 0x90, 0x00]));
+  writeFileSync(linuxBinary, Buffer.from([0x7f, 0x45, 0x4c, 0x46]));
+  writeFileSync(macBinary, Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+
+  verifyBinaryFormat(windowsBinary, 'win32');
+  verifyBinaryFormat(linuxBinary, 'linux');
+  verifyBinaryFormat(macBinary, 'darwin');
+
+  assert.throws(
+    () => verifyBinaryFormat(macBinary, 'win32'),
+    /binary format does not match win32/,
+  );
+  assert.throws(
+    () => verifyBinaryFormat(windowsBinary, 'darwin'),
+    /binary format does not match darwin/,
+  );
 });

--- a/tests/postinstall.test.cjs
+++ b/tests/postinstall.test.cjs
@@ -14,6 +14,7 @@ const {
   sha256,
   verifyBinaryFormat,
   verifyChecksum,
+  verifyInstalledBinary,
 } = require('../npm/postinstall.cjs');
 
 test('maps supported platforms to Rust targets', () => {
@@ -64,5 +65,12 @@ test('verifies native binary formats before installation', () => {
   assert.throws(
     () => verifyBinaryFormat(windowsBinary, 'darwin'),
     /binary format does not match darwin/,
+  );
+});
+
+test('rejects executable version output from a different program', () => {
+  assert.throws(
+    () => verifyInstalledBinary(process.execPath, process.platform),
+    /unexpected version output/,
   );
 });


### PR DESCRIPTION
## 查證結果

Issue #15 所述錯誤只存在於 macOS 編譯分支。已下載並檢查 v0.2.9 官方 Windows asset：

- zip SHA-256：`6d8e4839e799a240508bba0763ffd7f6be4e01d594a61e8303afd903eb15b645`，與 release checksum 一致。
- `ask-bridge.exe` 與 updater 均為 PE32+ x86-64 Windows 執行檔。
- Windows 主程式含標準 Windows Chrome 路徑錯誤訊息。
- Windows 主程式不含 `/Applications/Google Chrome.app` 字串。

因此不是 Windows build 誤判作業系統，而是安裝後執行到其他路徑或錯誤平台的舊 binary。現有 PowerShell installer 把正式安裝目錄放在 PATH 尾端，確實可能讓既有命令繼續遮蔽新安裝檔。

## 修正

- PowerShell installer 在複製前驗證 Windows PE `MZ` header。
- 安裝後執行 `ask-bridge.exe --version` smoke test。
- 將 `$HOME\.local\bin` 移到 User PATH 與目前程序 PATH 最前面。
- 驗證 `Get-Command ask-bridge.exe` 實際解析到新安裝檔。
- npm postinstall 驗證 Windows、Linux 與 macOS native binary magic，並執行版本 smoke test。
- release workflow 在打包前驗證 Windows PE header 與版本輸出。
- CI 新增 Windows runner，執行 npm 測試與 PowerShell installer 語法解析。
- README 與 Agent Skill 補上 `where.exe ask-bridge` 診斷方式。

## 驗證

- `cargo test`：70 項測試通過
- `npm test`：5 項測試通過
- `cargo fmt --all -- --check`
- Node 語法檢查
- PowerShell AST 語法解析
- PowerShell 版本 smoke test
- `git diff --check`

Fixes #15