### PR TITLE
feat(model): 分離 provider 推理模式選擇

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,7 @@ Unlike typical API clients, `ask-bridge` operates inside a real Chrome browser w
 - **🧠 Intelligent Tab Management**: Reuses existing provider tabs if open, focuses them, or opens new ones, avoiding tab clutter.
 - **🖥️ Pipe & Stdin Support**: Supports piping prompts via `stdin` (e.g. `cat report.txt | ask-bridge "summarize this"`).
 - **📎 Image & File Attachments**: Attach local images with `--image` (supported on ChatGPT and Claude), or documents (PDF, Word, Excel, plain text, Markdown, JSON, etc.) with `--file`; Gemini currently supports `--file` and rejects `--image`.
-- **🔀 Model Switching**: Use `--model` to switch the provider model before the prompt is sent, such as ChatGPT `GPT-5.4`, Gemini `3.5 Flash`, or Claude `Sonnet`.
+- **🔀 Model and Reasoning Selection**: Use `--model` for provider models and `--reasoning` for ChatGPT reasoning effort or Gemini Extended Thinking.
 - **Resume Conversations**: Use `--session`, `--session-id`, or `--session-url` to continue an existing provider conversation with a new terminal prompt.
 - **Response Timeout**: Use `--timeout <seconds>` to control how long to wait for a provider response, defaulting to `300` seconds.
 - **🔍 Quiet by Default & Verbose Mode**: Quiet and clean output by default (displaying only the generated response), with an optional `--verbose` flag to display full browser state logs if needed.
@@ -335,28 +335,27 @@ You can attach images and documents at the same time:
 ask-bridge "Compare this design image against the spec document and list inconsistencies." --image design.png --file spec.docx
 ```
 
-### 11. Switch Model
+### 11. Switch Models and Reasoning
 
-Use `--model` to automatically switch the provider model before the prompt is sent. Matching is case- and punctuation-insensitive (`-`, `.`, spaces, etc. are ignored).
+Use `--model` to switch the provider model before the prompt is sent. Use `--reasoning` separately for provider-specific reasoning modes. ChatGPT accepts both in one invocation; Gemini Extended Thinking is compatible only with Pro models.
 
 ```bash
-ask-bridge "Introduce Rust in a few sentences." --model GPT-5.4
-ask-bridge "Prove this math problem." --model o3
-ask-bridge "Quickly translate this." --model 即時
-ask-bridge --provider gemini "Introduce Rust in a few sentences." --model "3.5 Flash"
-ask-bridge --provider gemini "Introduce Rust in a few sentences." --model "3.1 Pro"
+ask-bridge "Prove this math problem." --model "GPT-5.6 Sol" --reasoning high
+ask-bridge "Quickly translate this." --reasoning instant
+ask-bridge --provider gemini "Introduce Rust in a few sentences." --model "3.6 Flash"
+ask-bridge --provider gemini "Prove this math problem." --model "3.1 Pro" --reasoning extended
 ask-bridge --provider claude "Introduce Rust in a few sentences." --model Sonnet
-ask-bridge --provider claude "Prove this math problem." --model Opus
 ```
 
-Available model names (depending on your account entitlements and provider UI):
+Argument rules:
 
-- **ChatGPT models**: `GPT-5.5`, `GPT-5.4`, `GPT-5.3`, `o3`
-- **ChatGPT thinking levels**: `智慧`, `即時`, `中等`, `高`, `超高`, `專業`
-- **Gemini modes**: `3.5 Flash`, `3.1 Flash-Lite`, `3.1 Pro`
-- **Claude models**: `Sonnet`, `Opus`, `Haiku` (actual names depend on the claude.ai menu and your plan)
+- **ChatGPT**: `--reasoning` accepts `auto`, `instant`, `medium`, and `high`, plus the corresponding aliases `智慧`, `即時`, `中`, `中等`, and `高`.
+- **Gemini**: `--reasoning extended` selects Extended Thinking. Omit `--model` or combine it with an available Pro model.
+- **Claude**: `--reasoning` is unsupported. Existing Sonnet, Opus, and Haiku `--model` selection is unchanged.
 
-> If the requested name is not found in the menu, `ask-bridge` reports `Model switch failed: error: model not found in menu` and aborts without submitting the prompt.
+Model matching uses only each menu item's primary label and ignores subtitles and badges. It remains case- and punctuation-insensitive. The tool never maps an obsolete model version to a different version. If the primary label is unavailable, the error lists the provider options currently found and aborts before sending the prompt.
+
+Legacy forms such as `--model 高` and Gemini `--model 延伸思考` remain temporarily supported with a deprecation warning. Use `--reasoning` instead.
 
 ### 12. Just Open a Provider
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - **智慧分頁管理**：可重用既有 provider 分頁、聚焦分頁，或開啟新分頁，避免分頁過度增加。
 - **Pipe 與 stdin 支援**：支援透過 standard input 傳入 prompt，例如 `cat report.txt | ask-bridge "summarize this"`。
 - **圖片與文件上傳**：可透過 `--image` 附上圖片（支援 ChatGPT 與 Claude），或透過 `--file` 附上文件（PDF、Word、Excel、純文字、Markdown、JSON 等皆可），一次可指定多個檔案；Gemini 目前支援 `--file`，不支援 `--image` 圖片輸入。
-- **模型切換**：使用 `--model` 在送出 prompt 前自動切換 provider 模型（如 ChatGPT 的 `GPT-5.4`、`o3`，Gemini 的 `3.5 Flash`、`3.1 Pro`，或 Claude 的 `Sonnet`、`Opus`）。
+- **模型與推理模式切換**：使用 `--model` 選模型，並以 `--reasoning` 分別控制 ChatGPT 推理強度或 Gemini 延伸思考。
 - **接續既有對話**：使用 `--session`、`--session-id` 或 `--session-url` 指定既有對話，再從終端機送出新的 prompt。
 - **回應超時**：使用 `--timeout <秒數>` 設定等待回應上限，預設為 `300` 秒。
 - **預設安靜模式與 verbose 模式**：預設只輸出最終回覆；加上 `--verbose` 可顯示背景瀏覽器控制流程。
@@ -334,28 +334,27 @@ ask-bridge "請對照這張設計圖與規格文件，指出不一致的地方�
 
 provider 回覆後，可使用 `-i` / `--image-output` 指定生成圖片的下載路徑（資料夾或檔案路徑）。
 
-### 11. 切換模型
+### 11. 切換模型與推理模式
 
-使用 `--model` 在送出 prompt 前自動切換 provider 的模型。比對時不分大小寫與標點符號（`-`、`.`、空格 等）。
+使用 `--model` 在送出 prompt 前切換 provider 模型；使用 `--reasoning` 分別指定 provider 支援的推理模式。兩者可在同一次 ChatGPT 呼叫中併用；Gemini 的延伸思考只相容於 Pro 模型。
 
 ```bash
-ask-bridge "用幾句話介紹 Rust。" --model GPT-5.4
-ask-bridge "證明這個數學問題。" --model o3
-ask-bridge "快速翻譯這段話。" --model 即時
-ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.5 Flash"
-ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.1 Pro"
+ask-bridge "證明這個數學問題。" --model "GPT-5.6 Sol" --reasoning high
+ask-bridge "快速翻譯這段話。" --reasoning instant
+ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.6 Flash"
+ask-bridge --provider gemini "證明這個數學問題。" --model "3.1 Pro" --reasoning extended
 ask-bridge --provider claude "用幾句話介紹 Rust。" --model Sonnet
-ask-bridge --provider claude "證明這個數學問題。" --model Opus
 ```
 
-可用的模型名稱（視帳號權限與 provider UI 而定）：
+參數規則：
 
-- **ChatGPT 模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
-- **ChatGPT 思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
-- **Gemini 模式**：`3.5 Flash`、`3.1 Flash-Lite`、`3.1 Pro`
-- **Claude 模型**：`Sonnet`、`Opus`、`Haiku`（實際名稱依 claude.ai 選單與帳號方案而定）
+- **ChatGPT**：`--reasoning` 支援 `auto`、`instant`、`medium`、`high`，也接受 `智慧`、`即時`、`中`、`中等`、`高` 等對應別名。
+- **Gemini**：`--reasoning extended` 選擇 Extended Thinking；可省略 `--model`，或搭配實際存在的 Pro 模型。
+- **Claude**：不支援 `--reasoning`；`--model` 的 Sonnet、Opus、Haiku 選擇流程維持不變。
 
-> 若指定的名稱在選單中找不到，`ask-bridge` 會回報 `Model switch failed: error: model not found in menu` 並中止，不會送出 prompt。
+模型比對只使用選單的主標籤，忽略副標題與 badge；比對仍不分大小寫與標點。工具不會把舊版模型名稱自動改選為其他版本。若主標籤不存在，錯誤會列出目前讀到的 provider 選項，並在送出 prompt 前中止。
+
+舊用法如 `--model 高` 或 Gemini 的 `--model 延伸思考` 暫時仍可使用，但會顯示棄用警告；請改用 `--reasoning`。
 
 ### 12. 只開啟 provider
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -169,24 +169,25 @@ ask-bridge "幫我檢查這段程式碼。" --file src/main.rs
 ask-bridge "對照這張設計圖與規格文件，指出不一致處。" --image design.png --file spec.docx
 ```
 
-## 切換模型
+## 切換模型與推理模式
 
-使用 `--model` 在送出 prompt 前自動切換 provider 模型（不分大小寫與標點）：
+使用 `--model` 切換 provider 模型，並以 `--reasoning` 分別指定 ChatGPT 推理強度或 Gemini 延伸思考：
 
 ```sh
-ask-bridge "用幾句話介紹 Rust。" --model GPT-5.4
-ask-bridge "證明這個數學問題。" --model o3
-ask-bridge "快速翻譯這段話。" --model 即時
-ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.5 Flash"
+ask-bridge "證明這個數學問題。" --model "GPT-5.6 Sol" --reasoning high
+ask-bridge "快速翻譯這段話。" --reasoning instant
+ask-bridge --provider gemini "用幾句話介紹 Rust。" --model "3.6 Flash"
+ask-bridge --provider gemini "證明這個數學問題。" --model "3.1 Pro" --reasoning extended
 ask-bridge --provider claude "用幾句話介紹 Rust。" --model Sonnet
 ```
 
-可用名稱（視帳號權限與 provider UI）：
+推理值：
 
-- **ChatGPT 模型**：`GPT-5.5`、`GPT-5.4`、`GPT-5.3`、`o3`
-- **ChatGPT 思考強度**：`智慧`、`即時`、`中等`、`高`、`超高`、`專業`
-- **Gemini 模式**：`3.5 Flash`、`3.1 Flash-Lite`、`3.1 Pro`
-- **Claude 模型**：`Sonnet`、`Opus`、`Haiku`（實際名稱依 claude.ai 選單與帳號方案而定）
+- **ChatGPT**：`auto`、`instant`、`medium`、`high`，亦接受對應中文別名。
+- **Gemini**：`extended`，只能單獨使用或搭配 Pro 模型。
+- **Claude**：不支援 `--reasoning`，原有 `--model` 行為不變。
+
+模型名稱會與 provider 選單的主標籤精確比對，不會把舊版本名稱改選為其他版本；副標題與 badge 不參與比對。
 
 ## 關閉瀏覽器 instance
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -187,7 +187,7 @@ ask-bridge --provider claude "用幾句話介紹 Rust。" --model Sonnet
 - **Gemini**：`extended`，只能單獨使用或搭配 Pro 模型。
 - **Claude**：不支援 `--reasoning`，原有 `--model` 行為不變。
 
-模型名稱會與 provider 選單的主標籤精確比對，不會把舊版本名稱改選為其他版本；副標題與 badge 不參與比對。
+模型名稱只與 provider 選單的主標籤比對，忽略大小寫、標點、副標題與 badge；不會把舊版本名稱改選為其他版本。
 
 ## 關閉瀏覽器 instance
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "node npm/postinstall.cjs",
-    "test": "node --test tests/postinstall.test.cjs",
+    "test": "node --test tests/postinstall.test.cjs tests/model-selection.test.cjs",
     "prepublishOnly": "npm test && npm pack --dry-run && node npm/prepublish-check.cjs"
   },
   "files": [

--- a/skills/ask-bridge/SKILL.md
+++ b/skills/ask-bridge/SKILL.md
@@ -189,6 +189,7 @@ prompt + "\n\n" + stdin
 | `--file <FILE>` | 附加文件檔，可重複指定 | 支援 PDF、Word、Excel、PowerPoint、純文字、Markdown、CSV、JSON、程式碼等；ChatGPT、Gemini 與 Claude 都可用 |
 | `--timeout <SECONDS>` | 設定等待上限 | 必須是大於 0 的整數，預設 `300` 秒；同時套用於一般回覆與 `login` 登入偵測 |
 | `--model <MODEL>` | 送出 prompt 前切換模型 | 比對不分大小寫與標點；模型名稱取決於 provider UI 與帳號權限 |
+| `--reasoning <REASONING>` | 切換 provider 推理模式 | ChatGPT 支援 `auto`、`instant`、`medium`、`high`；Gemini 支援 `extended`；Claude 不支援 |
 | `-h`, `--help` | 顯示 help | 可用 `ask-bridge --help` 或 `ask-bridge help <COMMAND>` |
 | `config` | 設定或顯示全域預設 provider | 使用 `ask-bridge config --provider <chatgpt|gemini|claude>` |
 | `update` | 透過官方安裝指令重新安裝 | 只有使用者明確要求更新 ask-bridge 時才執行 |
@@ -321,23 +322,21 @@ ask-bridge --timeout 600 login
 
 `--timeout` 必須是大於 0 的整數。一般回覆逾時時，工具會停止等待並輸出警告；不要把空白或未完成的輸出當成有效回覆。登入逾時只代表仍未偵測到完成狀態，需檢查瀏覽器後再決定是否重試。
 
-## 模型切換
+## 模型與推理模式切換
 
-使用 `--model` 在送出 prompt 前切換模型：
+模型與推理模式是兩個獨立參數：
 
 ```sh
-ask-bridge '用幾句話介紹 Rust。' --model GPT-5.5
-ask-bridge '證明這個數學問題。' --model o3
-ask-bridge '快速翻譯這段話。' --model 即時
-ask-bridge --provider gemini '用幾句話介紹 Rust。' --model '3.5 Flash'
-ask-bridge --provider gemini '快速摘要這份文件。' --model '3.1 Flash-Lite'
-ask-bridge --provider gemini '用幾句話介紹 Rust。' --model '3.1 Pro'
+ask-bridge '證明這個數學問題。' --model 'GPT-5.6 Sol' --reasoning high
+ask-bridge '快速翻譯這段話。' --reasoning instant
+ask-bridge --provider gemini '用幾句話介紹 Rust。' --model '3.6 Flash'
+ask-bridge --provider gemini '證明這個數學問題。' --model '3.1 Pro' --reasoning extended
 ask-bridge --provider claude '用幾句話介紹 Rust。' --model Sonnet
-ask-bridge --provider claude '證明這個數學問題。' --model Opus
-ask-bridge --provider claude '快速摘要這份文件。' --model Haiku
 ```
 
-模型比對不分大小寫與標點符號。若切換失敗，移除 `--model` 或改用 provider 預設模型，不要猜測替代模型名稱。
+ChatGPT 的 `--reasoning` 支援 `auto`、`instant`、`medium`、`high` 與對應中文別名；Gemini 只支援 `extended`，且不能搭配非 Pro 模型；Claude 不支援 `--reasoning`。
+
+模型只比對 provider 選單的主標籤，忽略副標題與 badge，且不會把不存在的舊版本自動對應到其他版本。若切換失敗，應依錯誤列出的目前選項修正參數，不要猜測替代模型名稱。舊用法 `--model 高` 與 `--model 延伸思考` 暫時可用，但應改成 `--reasoning`。
 
 ## 對話與瀏覽器控制
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4862,7 +4862,9 @@ fn switch_semantic_option(
 
     let mut wait_cycles = 0;
     let mut status = String::from("pending");
-    while status == "pending" && wait_cycles < 75 {
+    // ChatGPT may wait up to 5s for the picker and traverse six nested levels
+    // twice when post-click verification must reopen the menu.
+    while status == "pending" && wait_cycles < 180 {
         thread::sleep(Duration::from_millis(200));
         let check_result = call_mcp_tool(
             config_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,6 +420,153 @@ impl fmt::Display for Provider {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReasoningRequest {
+    ChatGptAuto,
+    ChatGptInstant,
+    ChatGptMedium,
+    ChatGptHigh,
+    GeminiExtended,
+}
+
+impl ReasoningRequest {
+    fn target_aliases(self) -> &'static [&'static str] {
+        match self {
+            ReasoningRequest::ChatGptAuto => &["auto", "自動", "智慧"],
+            ReasoningRequest::ChatGptInstant => &["instant", "即時"],
+            ReasoningRequest::ChatGptMedium => &["medium", "中", "中等"],
+            ReasoningRequest::ChatGptHigh => &["high", "高"],
+            ReasoningRequest::GeminiExtended => &["extended thinking", "延伸思考"],
+        }
+    }
+
+    fn verification_aliases(self) -> &'static [&'static str] {
+        match self {
+            ReasoningRequest::GeminiExtended => {
+                &["extended thinking", "延伸思考", "pro extended", "pro 延伸"]
+            }
+            _ => self.target_aliases(),
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SelectionPlan {
+    model: Option<String>,
+    reasoning: Option<ReasoningRequest>,
+    used_legacy_model: bool,
+}
+
+fn normalize_option_label(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .filter(|character| character.is_alphanumeric())
+        .collect()
+}
+
+fn parse_chatgpt_reasoning(value: &str) -> Option<ReasoningRequest> {
+    match normalize_option_label(value).as_str() {
+        "auto" | "自動" | "智慧" => Some(ReasoningRequest::ChatGptAuto),
+        "instant" | "即時" => Some(ReasoningRequest::ChatGptInstant),
+        "medium" | "中" | "中等" => Some(ReasoningRequest::ChatGptMedium),
+        "high" | "高" => Some(ReasoningRequest::ChatGptHigh),
+        _ => None,
+    }
+}
+
+fn parse_gemini_reasoning(value: &str) -> Option<ReasoningRequest> {
+    match normalize_option_label(value).as_str() {
+        "extended" | "extendedthinking" | "延伸思考" | "proextended" | "pro延伸" => {
+            Some(ReasoningRequest::GeminiExtended)
+        }
+        _ => None,
+    }
+}
+
+fn is_gemini_pro_model(model: &str) -> bool {
+    let normalized = normalize_option_label(model);
+    if normalized == "pro" {
+        return true;
+    }
+
+    normalized.strip_suffix("pro").is_some_and(|version| {
+        !version.is_empty() && version.chars().all(|character| character.is_ascii_digit())
+    })
+}
+
+fn resolve_selection_plan(
+    provider: Provider,
+    model: Option<&str>,
+    reasoning: Option<&str>,
+) -> Result<SelectionPlan, String> {
+    let raw_model = model.map(str::trim);
+    if raw_model == Some("") {
+        return Err("Empty model name".to_string());
+    }
+    let model = raw_model.map(str::to_string);
+
+    let raw_reasoning = reasoning.map(str::trim);
+    if raw_reasoning == Some("") {
+        return Err("Empty reasoning value".to_string());
+    }
+
+    let explicit_reasoning = match (provider, raw_reasoning) {
+        (_, None) => None,
+        (Provider::ChatGpt, Some(value)) => Some(parse_chatgpt_reasoning(value).ok_or_else(|| {
+            format!(
+                "Unsupported ChatGPT reasoning '{value}'. Supported values: auto, instant, medium, high"
+            )
+        })?),
+        (Provider::Gemini, Some(value)) => Some(parse_gemini_reasoning(value).ok_or_else(|| {
+            format!("Unsupported Gemini reasoning '{value}'. Supported value: extended")
+        })?),
+        (Provider::Claude, Some(_)) => {
+            return Err(
+                "Claude does not support --reasoning; use --model for Sonnet, Opus, or Haiku"
+                    .to_string(),
+            );
+        }
+    };
+
+    let legacy_reasoning = match (provider, model.as_deref()) {
+        (Provider::ChatGpt, Some(value)) => parse_chatgpt_reasoning(value),
+        (Provider::Gemini, Some(value)) => parse_gemini_reasoning(value),
+        (Provider::Claude, _) | (_, None) => None,
+    };
+
+    if explicit_reasoning.is_some() && legacy_reasoning.is_some() {
+        return Err(
+            "A reasoning-like --model value cannot be combined with --reasoning; move the reasoning value to --reasoning"
+                .to_string(),
+        );
+    }
+
+    let (model, reasoning, used_legacy_model) = if let Some(legacy) = legacy_reasoning {
+        (None, Some(legacy), true)
+    } else {
+        (model, explicit_reasoning, false)
+    };
+
+    if provider == Provider::Gemini
+        && reasoning == Some(ReasoningRequest::GeminiExtended)
+        && model
+            .as_deref()
+            .is_some_and(|value| !is_gemini_pro_model(value))
+    {
+        return Err(
+            "Gemini Extended Thinking is incompatible with non-Pro models; omit --model or select a Pro model"
+                .to_string(),
+        );
+    }
+
+    Ok(SelectionPlan {
+        model,
+        reasoning,
+        used_legacy_model,
+    })
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct ChatGptAgentPrompt<'a> {
     agent_mention: &'a str,
@@ -526,12 +673,14 @@ struct Cli {
     timeout: u64,
 
     /// Switch the provider model before sending the prompt.
-    /// ChatGPT examples: "GPT-5.5", "GPT-5.4", "GPT-5.3", "o3", or thinking levels such as
-    /// "即時", "中等", "高", "超高", "專業", "智慧". Gemini examples: "3.5 Flash",
-    /// "3.1 Flash-Lite", or "3.1 Pro". Claude examples: "Sonnet", "Opus", "Haiku".
-    /// Matching is case- and punctuation-insensitive.
+    /// Use the exact primary menu label; subtitles and badges are ignored.
     #[arg(long = "model", value_name = "MODEL")]
     model: Option<String>,
+
+    /// Select provider-specific reasoning separately from the model.
+    /// ChatGPT: auto, instant, medium, high. Gemini: extended. Claude: unsupported.
+    #[arg(long = "reasoning", value_name = "REASONING")]
+    reasoning: Option<String>,
 }
 
 #[derive(Subcommand, Clone)]
@@ -2795,6 +2944,120 @@ mod tests {
     }
 
     #[test]
+    fn parses_reasoning_cli_argument() {
+        let cli = Cli::try_parse_from([
+            "ask-bridge",
+            "--provider",
+            "chatgpt",
+            "--model",
+            "GPT-5.6 Sol",
+            "--reasoning",
+            "high",
+            "solve",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.model.as_deref(), Some("GPT-5.6 Sol"));
+        assert_eq!(cli.reasoning.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn resolves_chatgpt_model_and_reasoning_independently() {
+        let plan =
+            resolve_selection_plan(Provider::ChatGpt, Some("GPT-5.6 Sol"), Some("medium")).unwrap();
+
+        assert_eq!(plan.model.as_deref(), Some("GPT-5.6 Sol"));
+        assert_eq!(plan.reasoning, Some(ReasoningRequest::ChatGptMedium));
+        assert!(!plan.used_legacy_model);
+    }
+
+    #[test]
+    fn resolves_chatgpt_reasoning_aliases() {
+        for (value, expected) in [
+            ("auto", ReasoningRequest::ChatGptAuto),
+            ("自動", ReasoningRequest::ChatGptAuto),
+            ("智慧", ReasoningRequest::ChatGptAuto),
+            ("instant", ReasoningRequest::ChatGptInstant),
+            ("即時", ReasoningRequest::ChatGptInstant),
+            ("medium", ReasoningRequest::ChatGptMedium),
+            ("中", ReasoningRequest::ChatGptMedium),
+            ("中等", ReasoningRequest::ChatGptMedium),
+            ("high", ReasoningRequest::ChatGptHigh),
+            ("高", ReasoningRequest::ChatGptHigh),
+        ] {
+            let plan = resolve_selection_plan(Provider::ChatGpt, None, Some(value)).unwrap();
+            assert_eq!(plan.reasoning, Some(expected), "unexpected alias {value}");
+        }
+    }
+
+    #[test]
+    fn converts_legacy_reasoning_like_model_values() {
+        let chatgpt = resolve_selection_plan(Provider::ChatGpt, Some("高"), None).unwrap();
+        assert_eq!(chatgpt.model, None);
+        assert_eq!(chatgpt.reasoning, Some(ReasoningRequest::ChatGptHigh));
+        assert!(chatgpt.used_legacy_model);
+
+        let gemini = resolve_selection_plan(Provider::Gemini, Some("延伸思考"), None).unwrap();
+        assert_eq!(gemini.model, None);
+        assert_eq!(gemini.reasoning, Some(ReasoningRequest::GeminiExtended));
+        assert!(gemini.used_legacy_model);
+    }
+
+    #[test]
+    fn validates_gemini_extended_thinking_combinations() {
+        let plan =
+            resolve_selection_plan(Provider::Gemini, Some("3.1 Pro"), Some("extended")).unwrap();
+        assert_eq!(plan.model.as_deref(), Some("3.1 Pro"));
+        assert_eq!(plan.reasoning, Some(ReasoningRequest::GeminiExtended));
+
+        let error = resolve_selection_plan(Provider::Gemini, Some("3.6 Flash"), Some("extended"))
+            .unwrap_err();
+        assert!(error.contains("incompatible"));
+    }
+
+    #[test]
+    fn rejects_unsupported_or_ambiguous_reasoning_values() {
+        let unsupported =
+            resolve_selection_plan(Provider::ChatGpt, None, Some("ultra")).unwrap_err();
+        assert!(unsupported.contains("auto, instant, medium, high"));
+
+        let ambiguous =
+            resolve_selection_plan(Provider::ChatGpt, Some("高"), Some("high")).unwrap_err();
+        assert!(ambiguous.contains("cannot be combined"));
+    }
+
+    #[test]
+    fn rejects_claude_reasoning_without_changing_model_selection() {
+        let error =
+            resolve_selection_plan(Provider::Claude, Some("Sonnet"), Some("high")).unwrap_err();
+        assert!(error.contains("Claude"));
+        assert!(error.contains("--reasoning"));
+
+        let plan = resolve_selection_plan(Provider::Claude, Some("Sonnet"), None).unwrap();
+        assert_eq!(plan.model.as_deref(), Some("Sonnet"));
+        assert_eq!(plan.reasoning, None);
+    }
+
+    #[test]
+    fn preserves_claude_model_selector_script() {
+        let target = serde_json::to_string("Sonnet").unwrap();
+        let script = claude_model_switch_script(&target);
+
+        assert!(script.contains(r#"[data-testid="model-selector-dropdown"]"#));
+        assert!(script.contains("model|claude|opus|sonnet|haiku|fable"));
+        assert!(script.contains("startsWith(target)"));
+        assert!(script.contains(r#"const target = norm("Sonnet");"#));
+    }
+
+    #[test]
+    fn preserves_provider_baselines_without_reasoning() {
+        for provider in [Provider::ChatGpt, Provider::Gemini, Provider::Claude] {
+            let plan = resolve_selection_plan(provider, None, None).unwrap();
+            assert_eq!(plan, SelectionPlan::default());
+        }
+    }
+
+    #[test]
     fn finds_linux_google_chrome_command_from_path() {
         let root = make_test_dir("chrome_path");
         let first_dir = root.join("first");
@@ -4507,8 +4770,202 @@ fn upload_attachments_to_provider(
     Ok(())
 }
 
-/// Switch the selected provider to the specified model. The page must already be
-/// loaded and logged in. `model` is matched case- and punctuation-insensitively.
+#[derive(Clone, Copy)]
+enum SelectionKind {
+    Model,
+    Reasoning,
+}
+
+impl SelectionKind {
+    fn display_name(self) -> &'static str {
+        match self {
+            SelectionKind::Model => "model",
+            SelectionKind::Reasoning => "reasoning",
+        }
+    }
+}
+
+fn switch_semantic_option(
+    config_path: &str,
+    provider: Provider,
+    target_aliases: &[&str],
+    verification_aliases: &[&str],
+    kind: SelectionKind,
+    verbose: bool,
+) -> Result<(), String> {
+    if provider == Provider::Claude {
+        return Err("Semantic option selection is not supported for Claude".to_string());
+    }
+    let primary_target = target_aliases
+        .first()
+        .ok_or_else(|| format!("No {} target was provided", kind.display_name()))?;
+    if verification_aliases.is_empty() {
+        return Err(format!(
+            "No {} verification aliases were provided",
+            kind.display_name()
+        ));
+    }
+
+    let request = serde_json::json!({
+        "provider": provider.to_string(),
+        "targetAliases": target_aliases,
+        "verificationAliases": verification_aliases,
+    });
+    let request_json = serde_json::to_string(&request)
+        .map_err(|error| format!("Failed to serialize selection request: {error}"))?;
+    let helper = include_str!("model-selection.cjs");
+    let js = format!(
+        r#"() => {{
+            {helper}
+            window.__ask_bridge_selection_status = 'pending';
+            (async () => {{
+                try {{
+                    const result = await globalThis.AskBridgeModelSelection.selectProviderOption({request_json});
+                    if (result.ok) {{
+                        window.__ask_bridge_selection_status = 'success:' + result.selected;
+                    }} else {{
+                        const available = result.available && result.available.length
+                            ? '; available options: ' + result.available.join(', ')
+                            : '';
+                        window.__ask_bridge_selection_status = 'error: ' + result.error + available;
+                    }}
+                }} catch (error) {{
+                    window.__ask_bridge_selection_status = 'error: ' + error.message;
+                }}
+            }})();
+            return true;
+        }}"#
+    );
+
+    if verbose {
+        println!(
+            "Switching {} {} to '{}'...",
+            provider.display_name(),
+            kind.display_name(),
+            primary_target
+        );
+    }
+
+    let start_result = call_mcp_tool(
+        config_path,
+        "evaluate_script",
+        serde_json::json!({ "function": js }),
+    )?;
+    let start_parsed = parse_script_result(&start_result)?;
+    if !start_parsed.as_bool().unwrap_or(false) {
+        return Err(format!(
+            "Failed to initiate {} switch script",
+            kind.display_name()
+        ));
+    }
+
+    let mut wait_cycles = 0;
+    let mut status = String::from("pending");
+    while status == "pending" && wait_cycles < 75 {
+        thread::sleep(Duration::from_millis(200));
+        let check_result = call_mcp_tool(
+            config_path,
+            "evaluate_script",
+            serde_json::json!({
+                "function": "() => window.__ask_bridge_selection_status || 'pending'"
+            }),
+        )?;
+        status = parse_script_result(&check_result)?
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| format!("Invalid {} switch status", kind.display_name()))?;
+        wait_cycles += 1;
+    }
+
+    if status.starts_with("error:") {
+        return Err(format!("{} switch failed: {}", kind.display_name(), status));
+    }
+    if status == "pending" {
+        return Err(format!(
+            "Timed out waiting for {} switch",
+            kind.display_name()
+        ));
+    }
+    if !status.starts_with("success:") {
+        return Err(format!(
+            "Unexpected {} switch status: {status}",
+            kind.display_name()
+        ));
+    }
+
+    if verbose {
+        println!("{} switched successfully ({status})", kind.display_name());
+    }
+    thread::sleep(Duration::from_millis(500));
+
+    Ok(())
+}
+
+fn claude_model_switch_script(target_json: &str) -> String {
+    let template = r#"() => {
+        window.__switch_model_status = 'pending';
+        (async () => {
+            try {
+                const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+                const norm = (s) => (s || '').toLowerCase().replace(/[\s.\-_]/g, '');
+                const labelOf = (el) => ((el.innerText || el.textContent || '').split('\n')[0] || '').trim();
+                const target = norm(__TARGET_MODEL__);
+                if (!target) { window.__switch_model_status = 'error: empty target'; return; }
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
+                await sleep(300);
+                let trigger = document.querySelector('[data-testid="model-selector-dropdown"]');
+                if (!trigger) {
+                    trigger = Array.from(document.querySelectorAll('button')).find((button) => {
+                        const popup = button.getAttribute('aria-haspopup');
+                        if (popup !== 'menu' && popup !== 'listbox') return false;
+                        const label = [button.getAttribute('aria-label'), button.textContent].filter(Boolean).join(' ');
+                        return /model|claude|opus|sonnet|haiku|fable/i.test(label);
+                    });
+                }
+                if (!trigger) { window.__switch_model_status = 'error: Claude model selector not found'; return; }
+                trigger.click();
+                await sleep(800);
+                const visited = new Set();
+                let clicked = false;
+                let chosen = '';
+                for (let depth = 0; depth < 4 && !clicked; depth++) {
+                    const items = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"], [role="menuitemradio"]'));
+                    const leaves = items.filter((it) => it.getAttribute('aria-haspopup') !== 'menu');
+                    let match = leaves.find((it) => norm(labelOf(it)) === target);
+                    if (!match) match = leaves.find((it) => norm(labelOf(it)).startsWith(target));
+                    if (match) {
+                        match.click();
+                        clicked = true;
+                        chosen = labelOf(match);
+                        break;
+                    }
+                    const trigs = items.filter((it) => it.getAttribute('aria-haspopup') === 'menu');
+                    const trig = trigs.find((it) => !visited.has(norm(it.innerText)));
+                    if (!trig) break;
+                    visited.add(norm(trig.innerText));
+                    trig.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+                    trig.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+                    trig.click();
+                    await sleep(700);
+                }
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
+                if (!clicked) {
+                    window.__switch_model_status = 'error: model not found in menu';
+                    return;
+                }
+                await sleep(400);
+                window.__switch_model_status = 'success:' + chosen;
+            } catch (e) {
+                window.__switch_model_status = 'error: ' + e.message;
+            }
+        })();
+        return true;
+    }"#;
+    template.replace("__TARGET_MODEL__", target_json)
+}
+
+/// Switch the selected provider to the specified model. ChatGPT and Gemini use
+/// exact primary-label matching; Claude retains its existing selector path.
 fn switch_model(
     config_path: &str,
     provider: Provider,
@@ -4517,6 +4974,16 @@ fn switch_model(
 ) -> Result<(), String> {
     if model.trim().is_empty() {
         return Err("Empty model name".to_string());
+    }
+    if provider != Provider::Claude {
+        return switch_semantic_option(
+            config_path,
+            provider,
+            &[model.trim()],
+            &[model.trim()],
+            SelectionKind::Model,
+            verbose,
+        );
     }
     let target_json = serde_json::to_string(model.trim())
         .map_err(|e| format!("Failed to serialize model name: {}", e))?;
@@ -4529,189 +4996,7 @@ fn switch_model(
         );
     }
 
-    let js = match provider {
-        Provider::ChatGpt => {
-            // The script opens the composer pill menu, walks visible leaves and submenu
-            // triggers, and clicks the first leaf whose normalized label matches.
-            "() => {\n".to_string()
-                + "    window.__switch_model_status = 'pending';\n"
-                + "    (async () => {\n"
-                + "    try {\n"
-                + "        const sleep = (ms) => new Promise((r) => setTimeout(r, ms));\n"
-                + "        const norm = (s) => (s || '').toLowerCase().replace(/[\\s.\\-_]/g, '');\n"
-                + &format!("        const target = norm({});\n", target_json)
-                + "        if (!target) { window.__switch_model_status = 'error: empty target'; return; }\n"
-                + "        const visited = new Set();\n"
-                + "        const closeMenus = async () => {\n"
-                + "            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));\n"
-                + "            await sleep(400);\n"
-                + "        };\n"
-                + "        await closeMenus();\n"
-                + "        let pill = null;\n"
-                + "        for (let i = 0; i < 20; i++) {\n"
-                + "            pill = document.querySelector('button.__composer-pill');\n"
-                + "            if (pill) break;\n"
-                + "            await sleep(250);\n"
-                + "        }\n"
-                + "        if (!pill) { window.__switch_model_status = 'error: composer pill not found'; return; }\n"
-                + "        pill.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));\n"
-                + "        pill.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));\n"
-                + "        pill.click();\n"
-                + "        await sleep(800);\n"
-                + "        let clicked = false;\n"
-                + "        let chosen = '';\n"
-                + "        for (let depth = 0; depth < 6 && !clicked; depth++) {\n"
-                + "            const all = Array.from(document.querySelectorAll('[role=\"menuitem\"], [role=\"menuitemradio\"]'));\n"
-                + "            const leaves = all.filter((it) => it.getAttribute('aria-haspopup') !== 'menu');\n"
-                + "            for (const it of leaves) {\n"
-                + "                const t = norm(it.innerText);\n"
-                + "                if (t && t === target) {\n"
-                + "                    it.click();\n"
-                + "                    clicked = true;\n"
-                + "                    chosen = it.innerText;\n"
-                + "                    break;\n"
-                + "                }\n"
-                + "            }\n"
-                + "            if (clicked) break;\n"
-                + "            const trigs = all.filter((it) => it.getAttribute('aria-haspopup') === 'menu');\n"
-                + "            const trig = trigs.find((it) => {\n"
-                + "                const k = norm(it.innerText) + '|' + (it.getAttribute('aria-label') || '');\n"
-                + "                return !visited.has(k);\n"
-                + "            });\n"
-                + "            if (!trig) break;\n"
-                + "            visited.add(norm(trig.innerText) + '|' + (trig.getAttribute('aria-label') || ''));\n"
-                + "            trig.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));\n"
-                + "            trig.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));\n"
-                + "            trig.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));\n"
-                + "            trig.click();\n"
-                + "            await sleep(750);\n"
-                + "        }\n"
-                + "        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));\n"
-                + "        if (!clicked) {\n"
-                + "            window.__switch_model_status = 'error: model not found in menu';\n"
-                + "            return;\n"
-                + "        }\n"
-                + "        window.__switch_model_status = 'success:' + chosen;\n"
-                + "    } catch (e) {\n"
-                + "        window.__switch_model_status = 'error: ' + e.message;\n"
-                + "    }\n"
-                + "    })();\n"
-                + "    return true;\n"
-                + "}"
-        }
-        Provider::Gemini => {
-            let template = r#"() => {
-                window.__switch_model_status = 'pending';
-                (async () => {
-                    try {
-                        const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-                        const norm = (s) => (s || '').toLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, '');
-                        const canonical = (s) => {
-                            const n = norm(s).replace(/^已選取/, '');
-                            if (n.includes('flashlite') || n.includes('31flashlite')) return 'flashlite';
-                            if (n.includes('35flash') || (n.endsWith('flash') && !n.includes('lite'))) return 'flash';
-                            if (n.includes('31pro') || n === 'pro') return 'pro';
-                            return n;
-                        };
-                        const target = canonical(__TARGET_MODEL__);
-                        if (!target) { window.__switch_model_status = 'error: empty target'; return; }
-                        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
-                        await sleep(250);
-                        const buttons = Array.from(document.querySelectorAll('button'));
-                        const modeButton = buttons.find((button) => /模式挑選器|model picker|mode picker/i.test([
-                            button.getAttribute('aria-label'),
-                            button.textContent
-                        ].filter(Boolean).join(' ')));
-                        if (!modeButton) { window.__switch_model_status = 'error: Gemini mode picker not found'; return; }
-                        modeButton.click();
-                        await sleep(800);
-                        const items = Array.from(document.querySelectorAll('[role="menuitem"], [role="menuitemradio"]'));
-                        let chosen = null;
-                        for (const item of items) {
-                            const label = item.innerText || item.textContent || item.getAttribute('aria-label') || '';
-                            if (canonical(label) === target || norm(label) === norm(__TARGET_MODEL__)) {
-                                chosen = item;
-                                break;
-                            }
-                        }
-                        if (!chosen) {
-                            window.__switch_model_status = 'error: model not found in menu';
-                            return;
-                        }
-                        chosen.click();
-                        await sleep(500);
-                        window.__switch_model_status = 'success:' + (chosen.innerText || chosen.textContent || '').trim();
-                    } catch (e) {
-                        window.__switch_model_status = 'error: ' + e.message;
-                    }
-                })();
-                return true;
-            }"#;
-            template.replace("__TARGET_MODEL__", &target_json)
-        }
-        Provider::Claude => {
-            let template = r#"() => {
-                window.__switch_model_status = 'pending';
-                (async () => {
-                    try {
-                        const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-                        const norm = (s) => (s || '').toLowerCase().replace(/[\s.\-_]/g, '');
-                        const labelOf = (el) => ((el.innerText || el.textContent || '').split('\n')[0] || '').trim();
-                        const target = norm(__TARGET_MODEL__);
-                        if (!target) { window.__switch_model_status = 'error: empty target'; return; }
-                        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
-                        await sleep(300);
-                        let trigger = document.querySelector('[data-testid="model-selector-dropdown"]');
-                        if (!trigger) {
-                            trigger = Array.from(document.querySelectorAll('button')).find((button) => {
-                                const popup = button.getAttribute('aria-haspopup');
-                                if (popup !== 'menu' && popup !== 'listbox') return false;
-                                const label = [button.getAttribute('aria-label'), button.textContent].filter(Boolean).join(' ');
-                                return /model|claude|opus|sonnet|haiku|fable/i.test(label);
-                            });
-                        }
-                        if (!trigger) { window.__switch_model_status = 'error: Claude model selector not found'; return; }
-                        trigger.click();
-                        await sleep(800);
-                        const visited = new Set();
-                        let clicked = false;
-                        let chosen = '';
-                        for (let depth = 0; depth < 4 && !clicked; depth++) {
-                            const items = Array.from(document.querySelectorAll('[role="menuitem"], [role="option"], [role="menuitemradio"]'));
-                            const leaves = items.filter((it) => it.getAttribute('aria-haspopup') !== 'menu');
-                            let match = leaves.find((it) => norm(labelOf(it)) === target);
-                            if (!match) match = leaves.find((it) => norm(labelOf(it)).startsWith(target));
-                            if (match) {
-                                match.click();
-                                clicked = true;
-                                chosen = labelOf(match);
-                                break;
-                            }
-                            const trigs = items.filter((it) => it.getAttribute('aria-haspopup') === 'menu');
-                            const trig = trigs.find((it) => !visited.has(norm(it.innerText)));
-                            if (!trig) break;
-                            visited.add(norm(trig.innerText));
-                            trig.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
-                            trig.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-                            trig.click();
-                            await sleep(700);
-                        }
-                        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, bubbles: true }));
-                        if (!clicked) {
-                            window.__switch_model_status = 'error: model not found in menu';
-                            return;
-                        }
-                        await sleep(400);
-                        window.__switch_model_status = 'success:' + chosen;
-                    } catch (e) {
-                        window.__switch_model_status = 'error: ' + e.message;
-                    }
-                })();
-                return true;
-            }"#;
-            template.replace("__TARGET_MODEL__", &target_json)
-        }
-    };
+    let js = claude_model_switch_script(&target_json);
 
     let start_res = call_mcp_tool(
         config_path,
@@ -4756,6 +5041,22 @@ fn switch_model(
     thread::sleep(Duration::from_millis(500));
 
     Ok(())
+}
+
+fn switch_reasoning(
+    config_path: &str,
+    provider: Provider,
+    reasoning: ReasoningRequest,
+    verbose: bool,
+) -> Result<(), String> {
+    switch_semantic_option(
+        config_path,
+        provider,
+        reasoning.target_aliases(),
+        reasoning.verification_aliases(),
+        SelectionKind::Reasoning,
+        verbose,
+    )
 }
 
 fn wait_for_submit_status(config_path: &str) -> Result<String, String> {
@@ -5754,6 +6055,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
+    let selection_plan =
+        match resolve_selection_plan(provider, cli.model.as_deref(), cli.reasoning.as_deref()) {
+            Ok(plan) => plan,
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        };
+    if selection_plan.used_legacy_model {
+        eprintln!(
+            "Warning: reasoning-like --model values are deprecated; use --reasoning instead."
+        );
+    }
+
     if !command_verbose {
         // SAFETY: Called before spawning other threads and before loading MCP config.
         unsafe {
@@ -6145,10 +6460,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Switch model if requested (before uploading attachments / typing the prompt)
-    if let Some(m) = &cli.model
+    if let Some(m) = &selection_plan.model
         && let Err(e) = switch_model(&config_path, provider, m, command_verbose)
     {
         eprintln!("Error switching model: {}", e);
+        std::process::exit(1);
+    }
+    if let Some(reasoning) = selection_plan.reasoning
+        && let Err(e) = switch_reasoning(&config_path, provider, reasoning, command_verbose)
+    {
+        eprintln!("Error switching reasoning: {}", e);
         std::process::exit(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -673,7 +673,8 @@ struct Cli {
     timeout: u64,
 
     /// Switch the provider model before sending the prompt.
-    /// Use the exact primary menu label; subtitles and badges are ignored.
+    /// Match the primary menu label case- and punctuation-insensitively;
+    /// subtitles and badges are ignored.
     #[arg(long = "model", value_name = "MODEL")]
     model: Option<String>,
 

--- a/src/model-selection.cjs
+++ b/src/model-selection.cjs
@@ -10,7 +10,7 @@
   function normalizeLabel(value) {
     return String(value || '')
       .normalize('NFKC')
-      .toLocaleLowerCase()
+      .toLowerCase()
       .replace(/[^\p{Letter}\p{Number}]+/gu, '');
   }
 
@@ -33,7 +33,7 @@
       source.ariaSelected,
       source.dataSelected,
       source.dataState,
-    ].map((value) => String(value || '').toLocaleLowerCase());
+    ].map((value) => String(value || '').toLowerCase());
 
     return {
       primaryLabel: lines[0] || '',

--- a/src/model-selection.cjs
+++ b/src/model-selection.cjs
@@ -123,11 +123,46 @@
     return undefined;
   }
 
+  async function findProviderOption(config, menuSelector, available, sleep) {
+    const visited = new Set();
+    const maxDepth = config.provider === 'chatgpt' ? 6 : 1;
+
+    for (let depth = 0; depth < maxDepth; depth += 1) {
+      const elements = visibleElements(menuSelector);
+      const entries = elements.map(entryFromElement);
+      entries.forEach((entry) => available.add(entry.primaryLabel));
+      const leaves = entries.filter(
+        (entry) => entry.element.getAttribute('aria-haspopup') !== 'menu',
+      );
+      const chosen = findMatchingEntry(leaves, config.targetAliases);
+      if (chosen || config.provider !== 'chatgpt') return chosen;
+
+      const triggers = entries.filter(
+        (entry) => entry.element.getAttribute('aria-haspopup') === 'menu',
+      );
+      const trigger = triggers.find((entry) => {
+        const key = `${normalizeLabel(entry.primaryLabel)}|${entry.element.getAttribute('aria-label') || ''}`;
+        return !visited.has(key);
+      });
+      if (!trigger) return undefined;
+
+      const key = `${normalizeLabel(trigger.primaryLabel)}|${trigger.element.getAttribute('aria-label') || ''}`;
+      visited.add(key);
+      trigger.element.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+      trigger.element.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+      trigger.element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      trigger.element.click();
+      await sleep(750);
+    }
+
+    return undefined;
+  }
+
   async function selectProviderOption(config) {
-    const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+    const sleep = config.sleep
+      || ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
     const menuSelector = '[role="menuitem"], [role="menuitemradio"], [role="option"]';
     const available = new Set();
-    const visited = new Set();
 
     document.dispatchEvent(new KeyboardEvent('keydown', {
       key: 'Escape',
@@ -154,31 +189,7 @@
     dispatchClick(picker);
     await sleep(800);
 
-    let chosen;
-    const maxDepth = config.provider === 'chatgpt' ? 6 : 1;
-    for (let depth = 0; depth < maxDepth && !chosen; depth += 1) {
-      const elements = visibleElements(menuSelector);
-      const entries = elements.map(entryFromElement);
-      entries.forEach((entry) => available.add(entry.primaryLabel));
-      const leaves = entries.filter((entry) => entry.element.getAttribute('aria-haspopup') !== 'menu');
-      chosen = findMatchingEntry(leaves, config.targetAliases);
-      if (chosen || config.provider !== 'chatgpt') break;
-
-      const triggers = entries.filter((entry) => entry.element.getAttribute('aria-haspopup') === 'menu');
-      const trigger = triggers.find((entry) => {
-        const key = `${normalizeLabel(entry.primaryLabel)}|${entry.element.getAttribute('aria-label') || ''}`;
-        return !visited.has(key);
-      });
-      if (!trigger) break;
-
-      const key = `${normalizeLabel(trigger.primaryLabel)}|${trigger.element.getAttribute('aria-label') || ''}`;
-      visited.add(key);
-      trigger.element.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
-      trigger.element.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
-      trigger.element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-      trigger.element.click();
-      await sleep(750);
-    }
+    const chosen = await findProviderOption(config, menuSelector, available, sleep);
 
     if (!chosen) {
       document.dispatchEvent(new KeyboardEvent('keydown', {
@@ -208,8 +219,7 @@
       picker = findPicker(config.provider) || picker;
       dispatchClick(picker);
       await sleep(500);
-      const refreshedEntries = visibleElements(menuSelector).map(entryFromElement);
-      currentEntry = findMatchingEntry(refreshedEntries, config.targetAliases);
+      currentEntry = await findProviderOption(config, menuSelector, available, sleep);
       verified = selectionVerified(
         currentEntry,
         textOf(picker),

--- a/src/model-selection.cjs
+++ b/src/model-selection.cjs
@@ -1,0 +1,249 @@
+'use strict';
+
+(function initializeModelSelection(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  root.AskBridgeModelSelection = api;
+})(typeof globalThis === 'object' ? globalThis : this, function createModelSelection() {
+  function normalizeLabel(value) {
+    return String(value || '')
+      .normalize('NFKC')
+      .toLocaleLowerCase()
+      .replace(/[^\p{Letter}\p{Number}]+/gu, '');
+  }
+
+  function parseMenuEntry(input) {
+    const source = typeof input === 'string' ? { text: input } : (input || {});
+    const lines = String(source.text || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const selectedPrefix = /^(?:selected|已選取|已选中)\s*[:：]?\s*/i;
+    const textMarksSelected = Boolean(lines[0] && selectedPrefix.test(lines[0]));
+    if (textMarksSelected) {
+      lines[0] = lines[0].replace(selectedPrefix, '').trim();
+      if (!lines[0]) lines.shift();
+    }
+    const badgeText = String(source.badgeText || '').trim();
+    const secondaryLines = lines.slice(1).filter((line) => line !== badgeText);
+    const selectedValues = [
+      source.ariaChecked,
+      source.ariaSelected,
+      source.dataSelected,
+      source.dataState,
+    ].map((value) => String(value || '').toLocaleLowerCase());
+
+    return {
+      primaryLabel: lines[0] || '',
+      secondaryDescription: secondaryLines.join(' '),
+      badgeText,
+      selected: textMarksSelected
+        || selectedValues.some((value) => ['true', 'checked', 'selected'].includes(value)),
+      element: source.element,
+    };
+  }
+
+  function labelsMatch(label, aliases) {
+    const normalized = normalizeLabel(label);
+    return Boolean(normalized) && aliases.some((alias) => normalizeLabel(alias) === normalized);
+  }
+
+  function findMatchingEntry(entries, aliases) {
+    return entries.find((entry) => labelsMatch(entry.primaryLabel, aliases));
+  }
+
+  function availablePrimaryLabels(entries) {
+    return [...new Set(entries.map((entry) => entry.primaryLabel).filter(Boolean))];
+  }
+
+  function selectionVerified(entry, pickerText, verificationAliases) {
+    return Boolean(
+      (entry && entry.selected)
+      || labelsMatch(parseMenuEntry(pickerText).primaryLabel, verificationAliases),
+    );
+  }
+
+  function textOf(element) {
+    return element
+      ? (element.innerText || element.textContent || element.getAttribute('aria-label') || '')
+      : '';
+  }
+
+  function entryFromElement(element) {
+    const badge = element.querySelector
+      ? element.querySelector('[data-testid*="badge"], [class*="badge"]')
+      : null;
+    const selectedDescendant = element.querySelector
+      ? element.querySelector(
+        '[aria-checked="true"], [aria-selected="true"], [data-selected="true"], [data-state="checked"]',
+      )
+      : null;
+    return parseMenuEntry({
+      text: textOf(element),
+      ariaChecked: element.getAttribute('aria-checked')
+        || (selectedDescendant && selectedDescendant.getAttribute('aria-checked')),
+      ariaSelected: element.getAttribute('aria-selected')
+        || (selectedDescendant && selectedDescendant.getAttribute('aria-selected')),
+      dataSelected: element.getAttribute('data-selected')
+        || (selectedDescendant && selectedDescendant.getAttribute('data-selected')),
+      dataState: element.getAttribute('data-state')
+        || (selectedDescendant && selectedDescendant.getAttribute('data-state')),
+      badgeText: textOf(badge),
+      element,
+    });
+  }
+
+  function visibleElements(selector) {
+    return Array.from(document.querySelectorAll(selector)).filter((element) => {
+      if (typeof element.getClientRects !== 'function') return true;
+      return element.getClientRects().length > 0;
+    });
+  }
+
+  function dispatchClick(element) {
+    element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    element.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    element.click();
+  }
+
+  function findPicker(provider) {
+    if (provider === 'chatgpt') {
+      return document.querySelector('button.__composer-pill');
+    }
+    if (provider === 'gemini') {
+      return visibleElements('button').find((button) => (
+        /模式挑選器|model picker|mode picker/i.test([
+          button.getAttribute('aria-label'),
+          button.textContent,
+        ].filter(Boolean).join(' '))
+      ));
+    }
+    return undefined;
+  }
+
+  async function selectProviderOption(config) {
+    const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+    const menuSelector = '[role="menuitem"], [role="menuitemradio"], [role="option"]';
+    const available = new Set();
+    const visited = new Set();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      keyCode: 27,
+      bubbles: true,
+    }));
+    await sleep(250);
+
+    let picker;
+    if (config.provider === 'chatgpt') {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        picker = findPicker(config.provider);
+        if (picker) break;
+        await sleep(250);
+      }
+    } else if (config.provider === 'gemini') {
+      picker = findPicker(config.provider);
+    }
+
+    if (!picker) {
+      return { ok: false, error: `${config.provider} picker not found`, available: [] };
+    }
+
+    dispatchClick(picker);
+    await sleep(800);
+
+    let chosen;
+    const maxDepth = config.provider === 'chatgpt' ? 6 : 1;
+    for (let depth = 0; depth < maxDepth && !chosen; depth += 1) {
+      const elements = visibleElements(menuSelector);
+      const entries = elements.map(entryFromElement);
+      entries.forEach((entry) => available.add(entry.primaryLabel));
+      const leaves = entries.filter((entry) => entry.element.getAttribute('aria-haspopup') !== 'menu');
+      chosen = findMatchingEntry(leaves, config.targetAliases);
+      if (chosen || config.provider !== 'chatgpt') break;
+
+      const triggers = entries.filter((entry) => entry.element.getAttribute('aria-haspopup') === 'menu');
+      const trigger = triggers.find((entry) => {
+        const key = `${normalizeLabel(entry.primaryLabel)}|${entry.element.getAttribute('aria-label') || ''}`;
+        return !visited.has(key);
+      });
+      if (!trigger) break;
+
+      const key = `${normalizeLabel(trigger.primaryLabel)}|${trigger.element.getAttribute('aria-label') || ''}`;
+      visited.add(key);
+      trigger.element.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
+      trigger.element.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
+      trigger.element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      trigger.element.click();
+      await sleep(750);
+    }
+
+    if (!chosen) {
+      document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        keyCode: 27,
+        bubbles: true,
+      }));
+      return {
+        ok: false,
+        error: 'option not found',
+        available: [...available].filter(Boolean),
+      };
+    }
+
+    chosen.element.click();
+    await sleep(600);
+
+    picker = findPicker(config.provider) || picker;
+    let currentEntry = entryFromElement(chosen.element);
+    let verified = selectionVerified(
+      currentEntry,
+      textOf(picker),
+      config.verificationAliases,
+    );
+
+    if (!verified) {
+      picker = findPicker(config.provider) || picker;
+      dispatchClick(picker);
+      await sleep(500);
+      const refreshedEntries = visibleElements(menuSelector).map(entryFromElement);
+      currentEntry = findMatchingEntry(refreshedEntries, config.targetAliases);
+      verified = selectionVerified(
+        currentEntry,
+        textOf(picker),
+        config.verificationAliases,
+      );
+    }
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      keyCode: 27,
+      bubbles: true,
+    }));
+
+    if (!verified) {
+      return {
+        ok: false,
+        error: `selection could not be verified for ${chosen.primaryLabel}`,
+        available: [...available].filter(Boolean),
+      };
+    }
+
+    return {
+      ok: true,
+      selected: chosen.primaryLabel,
+      available: [...available].filter(Boolean),
+    };
+  }
+
+  return {
+    availablePrimaryLabels,
+    findMatchingEntry,
+    normalizeLabel,
+    parseMenuEntry,
+    selectProviderOption,
+    selectionVerified,
+  };
+});

--- a/src/model-selection.cjs
+++ b/src/model-selection.cjs
@@ -103,8 +103,19 @@
   }
 
   function dispatchClick(element) {
-    element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
-    element.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    if (typeof PointerEvent === 'function') {
+      const pointerOptions = {
+        bubbles: true,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+      };
+      element.dispatchEvent(new PointerEvent('pointerdown', pointerOptions));
+      element.dispatchEvent(new PointerEvent('pointerup', pointerOptions));
+    } else {
+      element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    }
     element.click();
   }
 

--- a/src/model-selection.cjs
+++ b/src/model-selection.cjs
@@ -119,6 +119,23 @@
     element.click();
   }
 
+  function dispatchHover(element) {
+    if (typeof PointerEvent === 'function') {
+      const pointerOptions = {
+        bubbles: true,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+      };
+      element.dispatchEvent(new PointerEvent('pointerenter', pointerOptions));
+      element.dispatchEvent(new PointerEvent('pointermove', pointerOptions));
+    } else {
+      element.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      element.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    }
+    element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+  }
+
   function findPicker(provider) {
     if (provider === 'chatgpt') {
       return document.querySelector('button.__composer-pill');
@@ -159,9 +176,7 @@
 
       const key = `${normalizeLabel(trigger.primaryLabel)}|${trigger.element.getAttribute('aria-label') || ''}`;
       visited.add(key);
-      trigger.element.dispatchEvent(new MouseEvent('pointerenter', { bubbles: true }));
-      trigger.element.dispatchEvent(new MouseEvent('pointermove', { bubbles: true }));
-      trigger.element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      dispatchHover(trigger.element);
       trigger.element.click();
       await sleep(750);
     }

--- a/tests/model-selection.test.cjs
+++ b/tests/model-selection.test.cjs
@@ -7,6 +7,7 @@ const {
   availablePrimaryLabels,
   findMatchingEntry,
   parseMenuEntry,
+  selectProviderOption,
   selectionVerified,
 } = require('../src/model-selection.cjs');
 
@@ -95,4 +96,79 @@ test('verifies selection through checked state or the picker primary label', () 
   assert.equal(selectionVerified(unchecked, '高', ['high', '高']), true);
   assert.equal(selectionVerified(unchecked, '中', ['high', '高']), false);
   assert.equal(selectionVerified(undefined, 'Pro 延伸', ['Pro Extended', 'Pro 延伸']), true);
+});
+
+test('revisits ChatGPT nested menus when verifying a selected model', async () => {
+  const previousDocument = global.document;
+  const previousKeyboardEvent = global.KeyboardEvent;
+  const previousMouseEvent = global.MouseEvent;
+  let menuState = 'closed';
+
+  function element(text, attributes = {}, click = () => {}) {
+    return {
+      innerText: text,
+      textContent: text,
+      click,
+      dispatchEvent() {},
+      getAttribute(name) {
+        const value = typeof attributes[name] === 'function'
+          ? attributes[name]()
+          : attributes[name];
+        return value === undefined ? null : value;
+      },
+      getClientRects() {
+        return [{}];
+      },
+      querySelector() {
+        return null;
+      },
+    };
+  }
+
+  const picker = element('ChatGPT', {}, () => {
+    menuState = menuState === 'closed' ? 'top' : 'closed';
+  });
+  const submenu = element('更多模型', { 'aria-haspopup': 'menu' }, () => {
+    menuState = 'nested';
+  });
+  const model = element(
+    'GPT-5.6 Sol\n適合程式設計',
+    {
+      'aria-checked': () => (menuState === 'nested' ? 'true' : 'false'),
+    },
+    () => {
+      menuState = 'closed';
+    },
+  );
+
+  global.KeyboardEvent = class KeyboardEvent {};
+  global.MouseEvent = class MouseEvent {};
+  global.document = {
+    dispatchEvent() {},
+    querySelector(selector) {
+      return selector === 'button.__composer-pill' ? picker : null;
+    },
+    querySelectorAll(selector) {
+      if (selector === 'button') return [picker];
+      if (menuState === 'top') return [submenu];
+      if (menuState === 'nested') return [model];
+      return [];
+    },
+  };
+
+  try {
+    const result = await selectProviderOption({
+      provider: 'chatgpt',
+      targetAliases: ['GPT-5.6 Sol'],
+      verificationAliases: ['GPT-5.6 Sol'],
+      sleep: async () => {},
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.selected, 'GPT-5.6 Sol');
+  } finally {
+    global.document = previousDocument;
+    global.KeyboardEvent = previousKeyboardEvent;
+    global.MouseEvent = previousMouseEvent;
+  }
 });

--- a/tests/model-selection.test.cjs
+++ b/tests/model-selection.test.cjs
@@ -176,8 +176,12 @@ test('revisits ChatGPT nested menus when verifying a selected model', async () =
     assert.deepEqual(pointerEventTypes, [
       'pointerdown',
       'pointerup',
+      'pointerenter',
+      'pointermove',
       'pointerdown',
       'pointerup',
+      'pointerenter',
+      'pointermove',
     ]);
   } finally {
     global.document = previousDocument;

--- a/tests/model-selection.test.cjs
+++ b/tests/model-selection.test.cjs
@@ -102,6 +102,8 @@ test('revisits ChatGPT nested menus when verifying a selected model', async () =
   const previousDocument = global.document;
   const previousKeyboardEvent = global.KeyboardEvent;
   const previousMouseEvent = global.MouseEvent;
+  const previousPointerEvent = global.PointerEvent;
+  const pointerEventTypes = [];
   let menuState = 'closed';
 
   function element(text, attributes = {}, click = () => {}) {
@@ -143,6 +145,11 @@ test('revisits ChatGPT nested menus when verifying a selected model', async () =
 
   global.KeyboardEvent = class KeyboardEvent {};
   global.MouseEvent = class MouseEvent {};
+  global.PointerEvent = class PointerEvent {
+    constructor(type) {
+      pointerEventTypes.push(type);
+    }
+  };
   global.document = {
     dispatchEvent() {},
     querySelector(selector) {
@@ -166,9 +173,16 @@ test('revisits ChatGPT nested menus when verifying a selected model', async () =
 
     assert.equal(result.ok, true);
     assert.equal(result.selected, 'GPT-5.6 Sol');
+    assert.deepEqual(pointerEventTypes, [
+      'pointerdown',
+      'pointerup',
+      'pointerdown',
+      'pointerup',
+    ]);
   } finally {
     global.document = previousDocument;
     global.KeyboardEvent = previousKeyboardEvent;
     global.MouseEvent = previousMouseEvent;
+    global.PointerEvent = previousPointerEvent;
   }
 });

--- a/tests/model-selection.test.cjs
+++ b/tests/model-selection.test.cjs
@@ -1,0 +1,98 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  availablePrimaryLabels,
+  findMatchingEntry,
+  parseMenuEntry,
+  selectionVerified,
+} = require('../src/model-selection.cjs');
+
+function fixture(text, attributes = {}) {
+  return parseMenuEntry({
+    text,
+    ariaChecked: attributes.ariaChecked,
+    dataState: attributes.dataState,
+    badgeText: attributes.badgeText,
+  });
+}
+
+test('matches ChatGPT reasoning by primary label and ignores secondary version text', () => {
+  const entries = [
+    fixture('即時\n5.5'),
+    fixture('中'),
+    fixture('高'),
+  ];
+
+  assert.equal(findMatchingEntry(entries, ['instant', '即時']).primaryLabel, '即時');
+  assert.equal(findMatchingEntry(entries, ['medium', '中', '中等']).primaryLabel, '中');
+  assert.equal(findMatchingEntry(entries, ['high', '高']).primaryLabel, '高');
+  assert.equal(findMatchingEntry(entries, ['5.5']), undefined);
+});
+
+test('matches English ChatGPT reasoning labels', () => {
+  const entries = [
+    fixture('Instant\n5.5'),
+    fixture('Medium'),
+    fixture('High'),
+  ];
+
+  assert.equal(findMatchingEntry(entries, ['instant', '即時']).primaryLabel, 'Instant');
+  assert.equal(findMatchingEntry(entries, ['medium', '中', '中等']).primaryLabel, 'Medium');
+  assert.equal(findMatchingEntry(entries, ['high', '高']).primaryLabel, 'High');
+});
+
+test('matches Gemini modes exactly without subtitles or badges', () => {
+  const entries = [
+    fixture('3.5 Flash-Lite\n回覆最快\n新模型', { badgeText: '新模型' }),
+    fixture('3.6 Flash\n全方位協助\n新模型', { badgeText: '新模型' }),
+    fixture('3.1 Pro\n進階數學與程式設計'),
+    fixture('延伸思考\n解決複雜問題'),
+  ];
+
+  assert.equal(findMatchingEntry(entries, ['3.5 Flash-Lite']).primaryLabel, '3.5 Flash-Lite');
+  assert.equal(findMatchingEntry(entries, ['3.6 Flash']).primaryLabel, '3.6 Flash');
+  assert.equal(findMatchingEntry(entries, ['3.1 Pro']).primaryLabel, '3.1 Pro');
+  assert.equal(findMatchingEntry(entries, ['extended thinking', '延伸思考']).primaryLabel, '延伸思考');
+  assert.equal(findMatchingEntry(entries, ['3.5 Flash']), undefined);
+  assert.deepEqual(availablePrimaryLabels(entries), [
+    '3.5 Flash-Lite',
+    '3.6 Flash',
+    '3.1 Pro',
+    '延伸思考',
+  ]);
+});
+
+test('separates selected-state text from the Gemini primary label', () => {
+  const selected = fixture('已選取\n3.1 Pro\n進階數學與程式設計');
+  const selectedEnglish = fixture('Selected: Extended Thinking\nSolve complex problems');
+
+  assert.equal(selected.primaryLabel, '3.1 Pro');
+  assert.equal(selected.selected, true);
+  assert.equal(selectedEnglish.primaryLabel, 'Extended Thinking');
+  assert.equal(selectedEnglish.selected, true);
+});
+
+test('matches English Gemini Extended Thinking label', () => {
+  const entries = [
+    fixture('3.1 Pro\nAdvanced math and coding'),
+    fixture('Extended Thinking\nSolve complex problems'),
+  ];
+
+  assert.equal(
+    findMatchingEntry(entries, ['extended thinking', '延伸思考']).primaryLabel,
+    'Extended Thinking',
+  );
+});
+
+test('verifies selection through checked state or the picker primary label', () => {
+  const checked = fixture('高', { ariaChecked: 'true' });
+  const unchecked = fixture('高', { ariaChecked: 'false' });
+
+  assert.equal(selectionVerified(checked, '', ['high', '高']), true);
+  assert.equal(selectionVerified(unchecked, '高', ['high', '高']), true);
+  assert.equal(selectionVerified(unchecked, '中', ['high', '高']), false);
+  assert.equal(selectionVerified(undefined, 'Pro 延伸', ['Pro Extended', 'Pro 延伸']), true);
+});


### PR DESCRIPTION
## 問題

`--model` 同時承擔模型與推理強度，且 ChatGPT、Gemini 以完整 `innerText` 比對，會把副標題、版本提示與 badge 一併納入，導致有效的主標籤無法選取，也無法同時指定模型與推理模式。

## 修正

- 新增獨立 `--reasoning`：
  - ChatGPT：`auto`、`instant`、`medium`、`high` 與對應中文別名。
  - Gemini：`extended`。
  - Claude：在 Chrome 啟動前明確拒絕，原有 `--model` selector 不變。
- 以型別化 `SelectionPlan` 在瀏覽器自動化前驗證 provider 組合。
- ChatGPT 可同時指定模型與推理強度。
- Gemini Extended Thinking 可單獨使用或搭配 Pro 模型；Flash 等不相容組合會提前失敗。
- ChatGPT、Gemini 改用選單主標籤精確比對，忽略副標題與 badge，不會把舊版模型名稱映射成其他版本。
- 點擊後以 `aria-checked`、selected state 或 picker 主標籤驗證實際選取結果。
- 找不到選項時列出目前讀到的 provider 選項。
- 暫時接受 `--model 高` 與 Gemini `--model 延伸思考` 等舊用法，轉換後顯示棄用警告。
- 更新 CLI help、README、英文 README、快速入門與 Agent Skill。

## 驗證

- `cargo fmt --all -- --check`
- `cargo test --no-fail-fast`：79 項通過
- `cargo clippy --all-targets -- -D warnings`
- `npm test`：12 項通過
- `node --check src/model-selection.cjs`
- `git diff --check`
- 手動 CLI 驗證 Claude `--reasoning` 在 Chrome 啟動前失敗

Fixes #16